### PR TITLE
Better --version handling

### DIFF
--- a/pkg/options/auth.go
+++ b/pkg/options/auth.go
@@ -187,14 +187,13 @@ func (a *AuthIAMCreds) Validate() error {
 }
 
 func (a *AuthIAMMetadataCredentials) DefineFlags(fs *pflag.FlagSet) {
+	// TODO @jorres allow this option in profile
 	fs.BoolVar(&a.Enabled, "use-metadata-credentials", false,
 		`Use metadata service on a virtual machine to get credentials
-                          For more info go to: cloud.yandex.ru/docs/compute/operations/vm-connect/auth-inside-vm
-                          Definition priority:
-                            1. This option
-                            2. Profile specified with --profile option
-                            3. "USE_METADATA_CREDENTIALS" environment variable
-                            4. Active configuration profile (default: 0)`)
+For more info go to: cloud.yandex.ru/docs/compute/operations/vm-connect/auth-inside-vm
+Definition priority:
+  1. This option
+  2. "USE_METADATA_CREDENTIALS" environment variable`)
 }
 
 func (a *AuthIAMMetadataCredentials) Validate() error {

--- a/pkg/options/types.go
+++ b/pkg/options/types.go
@@ -1,6 +1,9 @@
 package options
 
-import "time"
+import (
+	"fmt"
+	"time"
+)
 
 var AvailabilityModes = []string{"strong", "weak", "force"}
 
@@ -14,4 +17,8 @@ type VersionSpec struct {
 	Major int
 	Minor int
 	Patch int
+}
+
+func (v VersionSpec) String() string {
+	return fmt.Sprintf("%s%v.%v.%v", v.Sign, v.Major, v.Minor, v.Patch)
 }

--- a/pkg/options/types.go
+++ b/pkg/options/types.go
@@ -2,6 +2,8 @@ package options
 
 import (
 	"fmt"
+	"regexp"
+	"strconv"
 	"time"
 )
 
@@ -12,13 +14,96 @@ type StartedTime struct {
 	Direction rune
 }
 
-type VersionSpec struct {
+type MajorMinorPatchVersion struct {
 	Sign  string
 	Major int
 	Minor int
 	Patch int
 }
 
-func (v VersionSpec) String() string {
+type RawVersion struct {
+	Raw string
+}
+
+type VersionSpec interface {
+	Satisfies(otherVersion string) (bool, error)
+	String() string
+}
+
+func (v MajorMinorPatchVersion) String() string {
 	return fmt.Sprintf("%s%v.%v.%v", v.Sign, v.Major, v.Minor, v.Patch)
+}
+
+func compareMajorMinorPatch(sign string, nodeVersion, userVersion [3]int) bool {
+	res := 0
+	for i := 0; i < 3; i++ {
+		if nodeVersion[i] < userVersion[i] {
+			res = -1
+			break
+		} else if nodeVersion[i] > userVersion[i] {
+			res = 1
+			break
+		}
+	}
+
+	switch sign {
+	case "==":
+		return res == 0
+	case "<":
+		return res == -1
+	case ">":
+		return res == 1
+	case "!=":
+		return res != 0
+	}
+	return false
+}
+
+func tryParseWith(reString, version string) (int, int, int, bool) {
+	re := regexp.MustCompile(reString)
+	matches := re.FindStringSubmatch(version)
+	if len(matches) == 4 {
+		num1, _ := strconv.Atoi(matches[1])
+		num2, _ := strconv.Atoi(matches[2])
+		num3, _ := strconv.Atoi(matches[3])
+		return num1, num2, num3, true
+	}
+	return 0, 0, 0, false
+}
+
+func parseNodeVersion(version string) (int, int, int, error) {
+	pattern1 := `^ydb-stable-(\d+)-(\d+)-(\d+).*$`
+	major, minor, patch, parsed := tryParseWith(pattern1, version)
+	if parsed {
+		return major, minor, patch, nil
+	}
+
+	pattern2 := `^(\d+)\.(\d+)\.(\d+).*$`
+	major, minor, patch, parsed = tryParseWith(pattern2, version)
+	if parsed {
+		return major, minor, patch, nil
+	}
+
+	return 0, 0, 0, fmt.Errorf("failed to parse the version number in any of the known patterns")
+}
+
+func (v MajorMinorPatchVersion) Satisfies(otherVersion string) (bool, error) {
+	major, minor, patch, err := parseNodeVersion(otherVersion)
+	if err != nil {
+		return false, fmt.Errorf("Failed to extract major.minor.patch from version %s", otherVersion)
+	}
+
+	return compareMajorMinorPatch(
+		v.Sign,
+		[3]int{major, minor, patch},
+		[3]int{v.Major, v.Minor, v.Patch},
+	), nil
+}
+
+func (v RawVersion) Satisfies(otherVersion string) (bool, error) {
+	return v.Raw == otherVersion, nil
+}
+
+func (v RawVersion) String() string {
+	return v.Raw
 }

--- a/pkg/rolling/options.go
+++ b/pkg/rolling/options.go
@@ -114,9 +114,6 @@ func (o *RestartOptions) Validate() error {
 		if err != nil {
 			return err
 		}
-		fmt.Println("AAAAAAA")
-		fmt.Println(o.VersionSpec.String())
-		fmt.Println("AAAAAAA")
 	}
 
 	o.SSHArgs = utils.ParseSSHArgs(rawSSHUnparsedArgs)

--- a/pkg/rolling/options.go
+++ b/pkg/rolling/options.go
@@ -26,6 +26,14 @@ const (
 	DefaultCMSQueryIntervalSeconds = 10
 )
 
+var (
+	majorMinorPatchPattern = `^(>|<|!=|~=)(\d+|\*)\.(\d+|\*)\.(\d+|\*)$`
+	majorMinorPatchRegexp  = regexp.MustCompile(majorMinorPatchPattern)
+
+	rawPattern = `^==(.*)$`
+	rawRegexp  = regexp.MustCompile(rawPattern)
+)
+
 type RestartOptions struct {
 	AvailabilityMode   string
 	Hosts              []string
@@ -243,13 +251,7 @@ func (o *RestartOptions) GetNodeIds() ([]uint32, error) {
 }
 
 func parseVersionFlag(versionUnparsedFlag string) (options.VersionSpec, error) {
-	majorMinorPatchPattern := `^(>|<|!=|~=)(\d+|\*)\.(\d+|\*)\.(\d+|\*)$`
-	re1 := regexp.MustCompile(majorMinorPatchPattern)
-
-	rawPattern := `^==(.*)$`
-	re2 := regexp.MustCompile(rawPattern)
-
-	matches := re1.FindStringSubmatch(versionUnparsedFlag)
+	matches := majorMinorPatchRegexp.FindStringSubmatch(versionUnparsedFlag)
 	if len(matches) == 5 {
 		// `--version` value looks like (sign)major.minor.patch
 		major, _ := strconv.Atoi(matches[2])
@@ -263,7 +265,7 @@ func parseVersionFlag(versionUnparsedFlag string) (options.VersionSpec, error) {
 		}, nil
 	}
 
-	matches = re2.FindStringSubmatch(versionUnparsedFlag)
+	matches = rawRegexp.FindStringSubmatch(versionUnparsedFlag)
 	if len(matches) == 2 {
 		// `--version` value is an arbitrary string value, and will
 		// be compared directly

--- a/pkg/rolling/options.go
+++ b/pkg/rolling/options.go
@@ -245,7 +245,6 @@ func (o *RestartOptions) GetNodeIds() ([]uint32, error) {
 	return ids, nil
 }
 
-
 func parseVersionFlag(versionUnparsedFlag string) (options.VersionSpec, error) {
 	majorMinorPatchPattern := `^(>|<|!=|~=)(\d+|\*)\.(\d+|\*)\.(\d+|\*)$`
 	re1 := regexp.MustCompile(majorMinorPatchPattern)
@@ -277,6 +276,6 @@ func parseVersionFlag(versionUnparsedFlag string) (options.VersionSpec, error) {
 	}
 
 	return nil, fmt.Errorf(
-		"Failed to interpret the value of `--version` flag. Read `ydbops restart --help` for more info on what is expected.",
+		"failed to interpret the value of `--version` flag. Read `ydbops restart --help` for more info on what is expected",
 	)
 }

--- a/pkg/rolling/restarters/common_k8s.go
+++ b/pkg/rolling/restarters/common_k8s.go
@@ -138,7 +138,6 @@ func (r *k8sRestarter) restartNodeByRestartingPod(nodeFQDN, namespace string) er
 		podName,
 		metav1.DeleteOptions{},
 	)
-
 	if err != nil {
 		return err
 	}

--- a/pkg/rolling/restarters/interface.go
+++ b/pkg/rolling/restarters/interface.go
@@ -20,7 +20,7 @@ type ClusterNodesInfo struct {
 }
 
 type FilterNodeParams struct {
-	Version         *options.VersionSpec
+	Version         options.VersionSpec
 	StartedTime     *options.StartedTime
 	ExcludeHosts    []string
 	SelectedTenants []string

--- a/pkg/rolling/rolling.go
+++ b/pkg/rolling/rolling.go
@@ -138,8 +138,6 @@ func (r *Rolling) DoRestart() error {
 		},
 	)
 
-	fmt.Printf("nodesToRestart %v\n", nodesToRestart)
-
 	excludedNodes := 0
 	for _, node := range nodesToRestart {
 		if _, present := r.state.inactiveNodes[node.NodeId]; present {


### PR DESCRIPTION

Before this PR, `--version ==MAJOR.MINOR.PATCH` matched both `23.3.1-ydb-stable-hotfix-1` and `23.3.1-ydb-stable-hotfix-2`. It WAS intended behaviour, utility looked at first `MAJOR.MINOR.PATCH` fragment in the node version.

@mvgorbunov mentioned it could lead to an incident, restarting something that is not supposed to be restarted. So the behaviour was split into two:

`--version ==STRING_LITERAL` now allows matching for the whole version string (e.g. you can now restart `--version ==23.3.1-ydb-stable-hotfix-1` and `...hotfix-2` will not be selected. 

`--version ~=MAJOR.MINOR.PATCH` behaves just like `--version ==MAJOR.MINOR.PATCH` behaved before this PR. 

To summarize:

1. It is now possible to match the entire version string, even if it's super weird like `stream-nb-tracing.1.<commit-hash>`
2. Changing == to ~=, it is a bit more explicit to the user that he selects a wideR configuration and needs to pay more attention. 