### PR TITLE
Add hosts range filtering

### DIFF
--- a/pkg/options/options_suite_test.go
+++ b/pkg/options/options_suite_test.go
@@ -37,3 +37,31 @@ var _ = Describe("Test parsing SSHArgs", func() {
 		),
 	)
 })
+
+var _ = Describe("Test parsing Hosts", func() {
+	It("Parse hosts as FQDNs with various symbols", func() {
+		Expect(utils.GetNodeFQDNs(
+			[]string{"simpleHost", "host-with-dashes", "abc.ydb.nebius.dev"},
+		)).To(Equal(
+			[]string{"simpleHost", "host-with-dashes", "abc.ydb.nebius.dev"},
+		))
+	})
+
+	DescribeTable("Parse host as ids",
+		func(input []string, expected []uint32) {
+			Expect(utils.GetNodeIds(input)).To(Equal(expected))
+		},
+		Entry("simplest case, three hosts each by themselves",
+			[]string{"1", "2", "3"},
+			[]uint32{1, 2, 3},
+		),
+		Entry("simplest range test",
+			[]string{"1-5"},
+			[]uint32{1, 2, 3, 4, 5},
+		),
+		Entry("real world example",
+			[]string{"1", "2", "3", "4-5"},
+			[]uint32{1, 2, 3, 4, 5},
+		),
+	)
+})

--- a/pkg/rolling/rolling.go
+++ b/pkg/rolling/rolling.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ydb-platform/ydbops/pkg/client/discovery"
 	"github.com/ydb-platform/ydbops/pkg/prettyprint"
 	"github.com/ydb-platform/ydbops/pkg/rolling/restarters"
+	"github.com/ydb-platform/ydbops/pkg/utils"
 )
 
 type Rolling struct {
@@ -112,8 +113,8 @@ func (r *Rolling) DoRestart() error {
 		return err
 	}
 
-	nodeIds, errIds := r.opts.GetNodeIds()
-	nodeFQDNs, errFqdns := r.opts.GetNodeFQDNs()
+	nodeIds, errIds := utils.GetNodeIds(r.opts.Hosts)
+	nodeFQDNs, errFqdns := utils.GetNodeFQDNs(r.opts.Hosts)
 	if errIds != nil && errFqdns != nil {
 		return fmt.Errorf(
 			"TODO parsing both in id mode and in fqdn mode failed: (%w), (%w)",

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -80,7 +80,7 @@ func GetNodeFQDNs(hostsRaw []string) ([]string, error) {
 		hostFQDNs = append(hostFQDNs, hostFQDN)
 	}
 
-	return hostsRaw, nil
+	return hostFQDNs, nil
 }
 
 func GetNodeIds(hosts []string) ([]uint32, error) {


### PR DESCRIPTION
Older versions of YDB do not always populate `version` and `startedTime` in CMS response. Filtering large node ranges on large clusters with such versions can be troublesome, as the only remaining way is to specify `--hosts=100,101,102...`. 

Now you can restart hosts in batches like this:

`--hosts=100-110` will restart nodes 100, 101, 102, ... 110.
`--hosts=1,2,3` still works and will restart nodes 1, 2, 3.

Hosts with dashes in fqdns are unaffected:

`--hosts=my-long-fqdn.ydb.dev` will restart a host with a given FQDN.