### PR TITLE
fix YDBOPS-10453

### DIFF
--- a/pkg/command/command.go
+++ b/pkg/command/command.go
@@ -45,7 +45,7 @@ func (o *BaseOptions) DefineFlags(fs *pflag.FlagSet) {
 		"Override currently set profile name from --config-file")
 
 	defaultProfileLocation := ""
-	if home, present := os.LookupEnv("HOME"); present {
+	if home, err := os.UserHomeDir(); err == nil {
 		defaultProfileLocation = filepath.Join(home, "ydb", "ydbops", "config", "config.yaml")
 	}
 


### PR DESCRIPTION
The default path to the config.yaml was incorrectly built under windows. os.UserHomeDir() works correctly under both Ubuntu and Windows