### PR TITLE
[rolling] add logging from CMS when no actions moved to performed state

### DIFF
--- a/pkg/rolling/rolling.go
+++ b/pkg/rolling/rolling.go
@@ -266,7 +266,12 @@ func (r *Rolling) processActionGroupStates(actions []*Ydb_Maintenance.ActionGrou
 	)
 
 	if len(performed) == 0 {
-		r.logger.Info("No actions can be taken yet, CMS didn't move any actions to PERFORMED because of: ", actionStatesBuf.String())
+		msg := actionStatesBuf.String()
+		if len(msg) == 0 {
+			msg = "<CMS does not support reporting details in this YDB version yet>"
+		}
+
+		r.logger.Info("No actions can be taken yet, CMS didn't move any actions to PERFORMED because of: ", msg)
 		return false
 	}
 

--- a/pkg/rolling/rolling.go
+++ b/pkg/rolling/rolling.go
@@ -266,7 +266,7 @@ func (r *Rolling) processActionGroupStates(actions []*Ydb_Maintenance.ActionGrou
 	)
 
 	if len(performed) == 0 {
-		r.logger.Info("No actions can be taken yet, waiting for CMS to move some actions to PERFORMED; Got issues: ", actionStatesBuf.String())
+		r.logger.Info("No actions can be taken yet, CMS didn't move any actions to PERFORMED because of: ", actionStatesBuf.String())
 		return false
 	}
 


### PR DESCRIPTION
There was no logging from CMS if actions were not moved to performed state for some reason.

This pull requests adds logging.

```
2024-10-02T17:38:30.090Z        info    No actions can be taken yet, waiting for CMS to move some actions to PERFORMED; Got issues: Issue in affected group with id '0': too many unavailable vdisks. Locked: VDisk [0:1:0:2:0] (shmel1k.shmel1k.net:/dev/disk/by-partlabel/shmel1k_nvme_01) is locked by this request. Down: Host abacaba.net:19001 (2) is down
```