### PR TITLE
Fix early exit in compatibility check

### DIFF
--- a/.changes/unreleased/Fixed-20241105-192850.yaml
+++ b/.changes/unreleased/Fixed-20241105-192850.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: ydbops now properly continues the restart loop even if listing nodes during maintenance check fails with "retry exceeded" error
+time: 2024-11-05T19:28:50.308019908+01:00


### PR DESCRIPTION
`ydbops` should not exit when listing nodes fails with "retry exceeded" error, and should just keep trying to do a full restarting loop from the beginning. 

Why? Maybe the node responding to listNodes CMS method has just been restarted by `ydbops`, it is a perfectly valid situation.