### PR TITLE
Fix the release workflow not acquiring a tag

### DIFF
--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -15,6 +15,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: get-latest-version
+      id: latest
       uses: miniscruff/changie-action@v2
       with:
         version: latest
@@ -24,18 +25,18 @@ jobs:
       uses: mathieudutour/github-tag-action@v6.2
       with:
         tag_prefix: ""
-        custom_tag: ${{ steps.get-latest-version.outputs.output }}
+        custom_tag: ${{ steps.latest.outputs.output }}
         github_token: ${{ github.token }}
 
     - name: build
       run: |
-        APP_VERSION=${{ steps.get-latest-version.outputs.output }} make build-in-docker 
+        APP_VERSION=${{ steps.latest.outputs.output }} make build-in-docker 
 
     - name: create-github-release
       uses: softprops/action-gh-release@v1
       with:
-        body_path: .changes/${{ steps.get-latest-version.outputs.output }}.md
+        body_path: .changes/${{ steps.latest.outputs.output }}.md
         files: bin/ydbops*
-        tag_name: ${{ steps.get-latest-version.outputs.output }} 
+        tag_name: ${{ steps.latest.outputs.output }} 
       env:
         GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
- make sure that `version` is propagated from `latest` step in releasing workflow