### PR TITLE
Introduce 'minor\patch' toggle to release job

### DIFF
--- a/.github/workflows/create-release-pr.yaml
+++ b/.github/workflows/create-release-pr.yaml
@@ -2,6 +2,15 @@ name: create-release-pr
 
 on:
   workflow_dispatch:
+    inputs:
+      bump_type:
+        description: 'Which version to bump when creating a release PR: minor or patch?'
+        required: true
+        default: 'patch'
+        type: choice
+        options:
+          - patch
+          - minor
 
 jobs:
   create-release-pr:
@@ -14,7 +23,7 @@ jobs:
       uses: miniscruff/changie-action@v2
       with:
         version: latest
-        args: batch patch
+        args: batch ${{ github.event.inputs.bump_type }}
 
     - name: merge-changes
       uses: miniscruff/changie-action@v2

--- a/.github/workflows/create-release-pr.yaml
+++ b/.github/workflows/create-release-pr.yaml
@@ -44,4 +44,8 @@ jobs:
         title: Release ${{ steps.latest.outputs.output }}
         branch: release/${{ steps.latest.outputs.output }}
         commit-message: Release ${{ steps.latest.outputs.output }}
+        body: |
+          Here is what a new entry in changelog would look like:
+
+            [`.changes/${{ steps.latest.outputs.output }}.md`](https://github.com/${{ github.repository }}/blob/release/${{ steps.latest.outputs.output }}/.changes/${{ steps.latest.outputs.output }}.md)
         token: ${{ github.token }}


### PR DESCRIPTION
- add a `minor\patch` toggle when launching the job `create-release-pr`, so it is now possible to bump minor versions
- render the changelog in the PR body, so the release author could see the release notes immediately

![image](https://github.com/user-attachments/assets/2196a4e4-3f3d-4346-871c-afd0584b5bbb)

