### PR TITLE
Fix `tag_and_release` job failing when triggered automatically

### DIFF
--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -15,6 +15,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
+        fetch-tags: true
 
     - name: get-latest-version
       id: latest

--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -13,6 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
 
     - name: get-latest-version
       id: latest


### PR DESCRIPTION
`tag_and_release` can be triggered either automatically (on push to `CHANGELOG.md`) or manually

When triggered manually, the defaults for the checkout actions differ slightly, which results in tags being checked out

When triggered automatically, the tag can not be found and thus job fails