### PR TITLE
[draft] add limitations for restart and wait between restarts

### DIFF
--- a/.changes/unreleased/Added-20241217-090915.yaml
+++ b/.changes/unreleased/Added-20241217-090915.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: nodes-inflight option, that limits inflight restarts
+time: 2024-12-17T09:09:15.576864642Z

--- a/.changes/unreleased/Added-20241217-091031.yaml
+++ b/.changes/unreleased/Added-20241217-091031.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: delay-between-restarts option that adds wait between two consecutive restarts
+time: 2024-12-17T09:10:31.958318067Z

--- a/pkg/rolling/options.go
+++ b/pkg/rolling/options.go
@@ -12,9 +12,11 @@ import (
 )
 
 const (
-	DefaultRetryCount              = 3
-	DefaultCMSQueryIntervalSeconds = 10
-	DefaultRestartDurationSeconds  = 60
+	DefaultRetryCount                  = 3
+	DefaultCMSQueryIntervalSeconds     = 10
+	DefaultRestartDurationSeconds      = 60
+	DefaultMaxConcurrentRestarts       = 1
+	DefaultDelayBetweenRestartsSeconds = 1
 )
 
 type RestartOptions struct {
@@ -22,6 +24,8 @@ type RestartOptions struct {
 
 	RestartRetryNumber         int
 	CMSQueryInterval           int
+	MaxConcurrentRestarts      int
+	DelayBetweenRestarts       int
 	SuppressCompatibilityCheck bool
 
 	RestartDuration int
@@ -87,8 +91,14 @@ the ydbops utility is stateless. Use at your own risk.`)
 after that would be considered a regular cluster failure`)
 
 	fs.BoolVar(&o.SuppressCompatibilityCheck, "suppress-compat-check", false,
-		`By default, nodes within one cluster can differ by at most one major release. 
+		`By default, nodes within one cluster can differ by at most one major release.
 ydbops will try to figure out if you broke this rule by comparing before\after of some restarted node.`)
+
+	fs.IntVar(&o.MaxConcurrentRestarts, "max-concurrent-restarts", DefaultMaxConcurrentRestarts,
+		`The limit on the number of simultaneous restarts`)
+
+	fs.IntVar(&o.DelayBetweenRestarts, "delay-between-restarts-seconds", DefaultDelayBetweenRestartsSeconds,
+		`Delay between two consecutive restarts in seconds. The number of simultaneous is set by 'max-concurrent-restarts'`)
 }
 
 func (o *RestartOptions) GetRestartDuration() *durationpb.Duration {

--- a/pkg/rolling/options.go
+++ b/pkg/rolling/options.go
@@ -12,11 +12,11 @@ import (
 )
 
 const (
-	DefaultRetryCount                  = 3
-	DefaultCMSQueryIntervalSeconds     = 10
-	DefaultRestartDurationSeconds      = 60
-	DefaultMaxConcurrentRestarts       = 1
-	DefaultDelayBetweenRestartsSeconds = 1
+	DefaultRetryCount              = 3
+	DefaultCMSQueryIntervalSeconds = 10
+	DefaultRestartDurationSeconds  = 60
+	DefaultNodesInflight           = 1
+	DefaultDelayBetweenRestarts    = time.Second
 )
 
 type RestartOptions struct {
@@ -24,8 +24,8 @@ type RestartOptions struct {
 
 	RestartRetryNumber         int
 	CMSQueryInterval           int
-	MaxConcurrentRestarts      int
-	DelayBetweenRestarts       int
+	NodesInflight              int
+	DelayBetweenRestarts       time.Duration
 	SuppressCompatibilityCheck bool
 
 	RestartDuration int
@@ -94,10 +94,10 @@ after that would be considered a regular cluster failure`)
 		`By default, nodes within one cluster can differ by at most one major release.
 ydbops will try to figure out if you broke this rule by comparing before\after of some restarted node.`)
 
-	fs.IntVar(&o.MaxConcurrentRestarts, "max-concurrent-restarts", DefaultMaxConcurrentRestarts,
-		`The limit on the number of simultaneous restarts`)
+	fs.IntVar(&o.NodesInflight, "nodes-inflight", DefaultNodesInflight,
+		`The limit on the number of simultaneous node restarts`)
 
-	fs.IntVar(&o.DelayBetweenRestarts, "delay-between-restarts-seconds", DefaultDelayBetweenRestartsSeconds,
+	fs.DurationVar(&o.DelayBetweenRestarts, "delay-between-restarts", DefaultDelayBetweenRestarts,
 		`Delay between two consecutive restarts in seconds. The number of simultaneous is set by 'max-concurrent-restarts'`)
 }
 

--- a/pkg/rolling/restart_handler.go
+++ b/pkg/rolling/restart_handler.go
@@ -100,7 +100,7 @@ func newRestartHandler(
 	return &restartHandler{
 		logger:                logger,
 		restarter:             restarter,
-		queue:                 make(chan *Ydb_Maintenance.ActionGroupStates, maxConcurrentRestarts),
+		queue:                 make(chan *Ydb_Maintenance.ActionGroupStates),
 		statusCh:              statusCh,
 		done:                  make(chan struct{}),
 		maxConcurrentRestarts: maxConcurrentRestarts,

--- a/pkg/rolling/restart_handler.go
+++ b/pkg/rolling/restart_handler.go
@@ -1,0 +1,112 @@
+package rolling
+
+import (
+	"sync"
+	"time"
+
+	"github.com/ydb-platform/ydb-go-genproto/draft/protos/Ydb_Maintenance"
+	"go.uber.org/zap"
+
+	"github.com/ydb-platform/ydbops/pkg/rolling/restarters"
+)
+
+type restartStatus struct {
+	nodeID uint32
+	as     *Ydb_Maintenance.ActionState
+	err    error
+}
+
+type restartHandler struct {
+	logger    *zap.SugaredLogger
+	queue     chan *Ydb_Maintenance.ActionGroupStates
+	restarter restarters.Restarter
+	statusCh  chan<- restartStatus
+
+	// TODO(shmel1k@): probably, not needed here.
+	nodes map[uint32]*Ydb_Maintenance.Node
+
+	onceDone sync.Once
+	done     chan struct{}
+	wg       sync.WaitGroup
+
+	maxConcurrentRestarts int
+}
+
+func (rh *restartHandler) push(state *Ydb_Maintenance.ActionGroupStates) {
+	select {
+	case <-rh.done:
+	case rh.queue <- state:
+	}
+}
+
+func (rh *restartHandler) run() {
+	for i := 0; i < rh.maxConcurrentRestarts; i++ {
+		rh.wg.Add(1)
+		go func() {
+			defer rh.wg.Done()
+
+			for {
+				select {
+				case <-rh.done:
+					return
+				case gs, ok := <-rh.queue:
+					if !ok {
+						return
+					}
+
+					var (
+						as   = gs.ActionStates[0]
+						lock = as.Action.GetLockAction()
+						node = rh.nodes[lock.Scope.GetNodeId()]
+					)
+
+					rh.logger.Debugf("Restart node with id: %d", node.GetNodeId())
+
+					// TODO(shmel1k@): draining should be implemented in RestartNode.
+					rh.logger.Debugf("Drain node with id: %d", node.GetNodeId())
+					// TODO: drain node, but public draining api is not available yet
+					rh.logger.Info("DRAINING NOT IMPLEMENTED YET")
+
+					rh.logger.Debugf("Restart node with id: %d", node.GetNodeId())
+					err := rh.restarter.RestartNode(node)
+					rh.statusCh <- restartStatus{
+						nodeID: lock.Scope.GetNodeId(),
+						as:     as,
+						err:    err,
+					}
+
+					select {
+					case <-rh.done:
+						return
+					case <-time.After(1 * time.Second):
+						continue
+					}
+				}
+			}
+		}()
+	}
+}
+
+func (rh *restartHandler) stop() {
+	rh.onceDone.Do(func() {
+		close(rh.done)
+	})
+}
+
+func newRestartHandler(
+	logger *zap.SugaredLogger,
+	restarter restarters.Restarter,
+	maxConcurrentRestarts int,
+	nodes map[uint32]*Ydb_Maintenance.Node,
+	statusCh chan<- restartStatus,
+) *restartHandler {
+	return &restartHandler{
+		logger:                logger,
+		restarter:             restarter,
+		queue:                 make(chan *Ydb_Maintenance.ActionGroupStates, maxConcurrentRestarts),
+		statusCh:              statusCh,
+		done:                  make(chan struct{}),
+		maxConcurrentRestarts: maxConcurrentRestarts,
+		nodes:                 nodes,
+	}
+}

--- a/pkg/rolling/restart_handler.go
+++ b/pkg/rolling/restart_handler.go
@@ -88,6 +88,7 @@ func (rh *restartHandler) run() {
 
 func (rh *restartHandler) stop() {
 	close(rh.done)
+	close(rh.queue)
 }
 
 func newRestartHandler(

--- a/pkg/rolling/restart_handler.go
+++ b/pkg/rolling/restart_handler.go
@@ -25,9 +25,8 @@ type restartHandler struct {
 	// TODO(shmel1k@): probably, not needed here.
 	nodes map[uint32]*Ydb_Maintenance.Node
 
-	onceDone sync.Once
-	done     chan struct{}
-	wg       sync.WaitGroup
+	done chan struct{}
+	wg   sync.WaitGroup
 
 	maxConcurrentRestarts int
 }
@@ -88,9 +87,7 @@ func (rh *restartHandler) run() {
 }
 
 func (rh *restartHandler) stop() {
-	rh.onceDone.Do(func() {
-		close(rh.done)
-	})
+	close(rh.done)
 }
 
 func newRestartHandler(

--- a/pkg/rolling/rolling.go
+++ b/pkg/rolling/rolling.go
@@ -314,12 +314,15 @@ func (r *Rolling) processActionGroupStates(actions []*Ydb_Maintenance.ActionGrou
 
 	r.completedActions = []*Ydb_Maintenance.ActionUid{}
 
-	// TODO(shmel1k@): increase this '1' and move to option
-	const (
-		maxConcurrentRestarts = 1
+	statusCh := make(chan restartStatus, r.opts.NodesInflight)
+	restartHandler := newRestartHandler(
+		r.logger,
+		r.restarter,
+		r.opts.NodesInflight,
+		r.opts.DelayBetweenRestarts,
+		r.state.nodes,
+		statusCh,
 	)
-	statusCh := make(chan restartStatus, maxConcurrentRestarts)
-	restartHandler := newRestartHandler(r.logger, r.restarter, maxConcurrentRestarts, r.state.nodes, statusCh)
 	restartHandler.run()
 	done := make(chan struct{})
 


### PR DESCRIPTION
Options and description

```
max-concurrent-restarts -- The limit on the number of simultaneous restarts
delay-between-restarts-seconds -- Delay between two consecutive restarts in seconds. The number of simultaneous is set by 'max-concurrent-restarts'
```