### PR TITLE
Fix `started` option's critically misleading help message

### DIFF
--- a/.changes/unreleased/Fixed-20241223-115035.yaml
+++ b/.changes/unreleased/Fixed-20241223-115035.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: --started option help contained a critically misleading typo (> vs <)
+time: 2024-12-23T11:50:35.744102865+01:00

--- a/pkg/options/targeting.go
+++ b/pkg/options/targeting.go
@@ -80,7 +80,7 @@ but you can not mix host FQDNs and node ids in this option. The list is comma-de
 		fmt.Sprintf(`Apply filter by node started time.
 Format: "<>%%Y-%%m-%%dT%%H:%%M:%%SZ", quotes are necessary, otherwise shell treats '<' or '>' as stream redirection.
 For example, --started ">2024-03-13T17:20:06Z" means all nodes started LATER than 2024 March 13, 17:20:06 UTC.
-If you reverse the sign (--started ">2024-03-13T17:20:06Z"), you will select nodes with LARGER uptimes.`))
+If you reverse the sign (--started "<2024-03-13T17:20:06Z"), you will select nodes with LARGER uptimes.`))
 
 	fs.StringVar(&versionUnparsedFlag, "version", "",
 		`Apply filter by node version.


### PR DESCRIPTION
Example was wrong, `>started...`, where `<started...` should have been.