### PR TITLE
Add --cleanup-on-exit

### DIFF
--- a/.changes/unreleased/Added-20250303-125045.yaml
+++ b/.changes/unreleased/Added-20250303-125045.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: New --cleanup-on-exit flag for `ydbops restart`. If specified, will intercept SIGTERM\SIGINT, safely finish current CMS batch and exit, cleaning up request
+time: 2025-03-03T12:50:45.370454584+01:00

--- a/.changes/unreleased/Changed-20250311-010253.yaml
+++ b/.changes/unreleased/Changed-20250311-010253.yaml
@@ -1,0 +1,3 @@
+kind: Changed
+body: bumped Go version to 1.23
+time: 2025-03-11T01:02:53.843594143+01:00

--- a/.changes/unreleased/Removed-20250303-132624.yaml
+++ b/.changes/unreleased/Removed-20250303-132624.yaml
@@ -1,0 +1,3 @@
+kind: Removed
+body: Removed an unimplemented --continue flag. Turned out it's not necessary, filtering by uptime etc is expressive and much simpler
+time: 2025-03-03T13:26:24.60035851+01:00

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v3
         with:
-          go-version: "1.21"
+          go-version: "1.23"
       - name: download dependencies
         run: |
           go mod download

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -24,7 +24,8 @@ run:
 # output configuration options
 output:
   # colored-line-number|line-number|json|tab|checkstyle, default is "colored-line-number"
-  formats: colored-line-number
+  formats:
+  - format: colored-line-number
 
   # print lines of code with issue, default is true
   print-issued-lines: true
@@ -43,12 +44,9 @@ linters-settings:
     # default is false: such cases aren't reported by default.
     check-blank: false
   govet:
-    # report about shadowed variables
-    check-shadowing: false
-    fieldalignment: true
-  golint:
-    # minimal confidence for issues, default is 0.8
-    min-confidence: 0.8
+    enable:
+      - shadow # report about shadowed variables
+      - fieldalignment # check struct field alignment
   gofmt:
     # simplify code: gofmt with `-s` option, true by default
     simplify: true
@@ -63,9 +61,6 @@ linters-settings:
     min-len: 2
     # minimal occurrences count to trigger, 3 by default
     min-occurrences: 2
-  fieldalignment:
-    # print struct with more effective memory layout or not, false by default
-    suggest-new: true
   misspell:
     # Correct spellings using locale preferences for US or UK.
     # Default is to use a neutral variety of English.
@@ -93,17 +88,7 @@ linters-settings:
       - name: empty-block
       - name: superfluous-else
       - name: unreachable-code
-  unused:
-    # treat code as a program (not a library) and report unused exported identifiers; default is false.
-    # XXX: if you enable this setting, unused will report a lot of false-positives in text editors:
-    # if it's called for subdir of a project it can't find funcs usages. All text editor integrations
-    # with golangci-lint call it on a directory with the changed file.
-    check-exported: false
   unparam:
-    # call graph construction algorithm (cha, rta). In general, use cha for libraries,
-    # and rta for programs with main packages. Default is cha.
-    algo: cha
-
     # Inspect exported functions, default is false. Set to true if no external program/library imports your code.
     # XXX: if you enable this setting, unparam will report a lot of false-positives in text editors:
     # if it's called for subdir of a project it can't find external interfaces. All text editor integrations
@@ -173,9 +158,6 @@ linters-settings:
         # The flag is passed to the ruleguard 'debug-group' argument.
         # Default: ""
         debug: 'emptyDecl'
-        # Deprecated, use 'failOn' param.
-        # If set to true, identical to failOn='all', otherwise failOn=''
-        failOnError: false
         # Determines the behavior when an error occurs while parsing ruleguard files.
         # If flag is not set, log error and skip rule files that contain an error.
         # If flag is set, the value must be a comma-separated list of error conditions.
@@ -290,8 +272,6 @@ issues:
   # Default value for this option is true.
   exclude-use-default: true
 
-  # Maximum issues count per one linter. Set to 0 to disable. Default is 50.
-  max-per-linter: 0
 
   # Maximum count of issues with the same text. Set to 0 to disable. Default is 3.
   max-same-issues: 0

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -46,7 +46,6 @@ linters-settings:
   govet:
     enable:
       - shadow # report about shadowed variables
-      - fieldalignment # check struct field alignment
   gofmt:
     # simplify code: gofmt with `-s` option, true by default
     simplify: true

--- a/pkg/rolling/options.go
+++ b/pkg/rolling/options.go
@@ -27,6 +27,7 @@ type RestartOptions struct {
 	NodesInflight              int
 	DelayBetweenRestarts       time.Duration
 	SuppressCompatibilityCheck bool
+	CleanupOnExit              bool
 
 	RestartDuration int
 
@@ -99,6 +100,9 @@ ydbops will try to figure out if you broke this rule by comparing before\after o
 
 	fs.DurationVar(&o.DelayBetweenRestarts, "delay-between-restarts", DefaultDelayBetweenRestarts,
 		`Delay between two consecutive restarts. E.g. '60s', '2m'. The number of simultaneous restarts is limited by 'nodes-inflight'.`)
+
+	fs.BoolVar(&o.CleanupOnExit, "cleanup-on-exit", false,
+		`When enabled, attempt to drop the maintenance task if the utility is killed by SIGTERM.`)
 }
 
 func (o *RestartOptions) GetRestartDuration() *durationpb.Duration {

--- a/pkg/rolling/options.go
+++ b/pkg/rolling/options.go
@@ -31,8 +31,6 @@ type RestartOptions struct {
 
 	RestartDuration int
 
-	Continue bool
-
 	SSHArgs []string
 
 	CustomSystemdUnitName string
@@ -82,11 +80,6 @@ Examples:
 	fs.IntVar(&o.CMSQueryInterval, "cms-query-interval", DefaultCMSQueryIntervalSeconds,
 		fmt.Sprintf("How often to query CMS while waiting for new permissions %v", DefaultCMSQueryIntervalSeconds))
 
-	fs.BoolVar(&o.Continue, "continue", false,
-		`Attempt to continue previous rolling restart, if there was one. The set of selected nodes
-for this invocation must be the same as for the previous invocation, and this can not be verified at runtime since
-the ydbops utility is stateless. Use at your own risk.`)
-
 	fs.IntVar(&o.RestartDuration, "duration", DefaultRestartDurationSeconds,
 		`CMS will release the node for maintenance for duration * restart-retry-number seconds. Any maintenance
 after that would be considered a regular cluster failure`)
@@ -101,7 +94,7 @@ ydbops will try to figure out if you broke this rule by comparing before\after o
 	fs.DurationVar(&o.DelayBetweenRestarts, "delay-between-restarts", DefaultDelayBetweenRestarts,
 		`Delay between two consecutive restarts. E.g. '60s', '2m'. The number of simultaneous restarts is limited by 'nodes-inflight'.`)
 
-	fs.BoolVar(&o.CleanupOnExit, "cleanup-on-exit", false,
+	fs.BoolVar(&o.CleanupOnExit, "cleanup-on-exit", true,
 		`When enabled, attempt to drop the maintenance task if the utility is killed by SIGTERM.`)
 }
 

--- a/pkg/rolling/rolling.go
+++ b/pkg/rolling/rolling.go
@@ -110,14 +110,9 @@ func (e *executer) Execute() error {
 			cancel()
 		}()
 	}
-	var err error
-	if e.opts.Continue {
-		e.logger.Info("Continue previous rolling restart")
-		err = r.DoRestartPrevious(ctx)
-	} else {
-		e.logger.Info("Start rolling restart")
-		err = r.DoRestart(ctx)
-	}
+
+	e.logger.Info("Start rolling restart")
+	err := r.DoRestart(ctx)
 
 	if errors.Is(err, context.Canceled) && e.opts.CleanupOnExit {
 		e.logger.Info("Operation was cancelled, cleaning up maintenance tasks")
@@ -206,10 +201,6 @@ func (r *Rolling) DoRestart(ctx context.Context) error {
 	}
 
 	return r.cmsWaitingLoop(ctx, task, len(nodesToRestart))
-}
-
-func (r *Rolling) DoRestartPrevious(ctx context.Context) error {
-	return fmt.Errorf("--continue behavior not implemented yet")
 }
 
 func (r *Rolling) cmsWaitingLoop(ctx context.Context, task cms.MaintenanceTask, totalNodes int) error {

--- a/pkg/rolling/rolling.go
+++ b/pkg/rolling/rolling.go
@@ -245,7 +245,7 @@ func (r *Rolling) cmsWaitingLoop(ctx context.Context, task cms.MaintenanceTask, 
 
 		r.logger.Infof("Wait next %s delay. Total node progress: %v out of %v", delay, restartedNodes, totalNodes)
 
-		if err := waitOrCancel(ctx, delay); err != nil {
+		if err = waitOrCancel(ctx, delay); err != nil {
 			return err
 		}
 

--- a/pkg/rolling/rolling.go
+++ b/pkg/rolling/rolling.go
@@ -573,13 +573,10 @@ func (r *Rolling) logCompleteResult(result *Ydb_Maintenance.ManageActionResult) 
 }
 
 func waitOrCancel(ctx context.Context, delay time.Duration) error {
-	timer := time.NewTimer(delay)
 	select {
 	case <-ctx.Done():
-		timer.Stop()
 		return ctx.Err()
-	case <-timer.C:
-		// Continue with operation, this was a regular wait
+	case <-time.After(delay):
 	}
 
 	return nil


### PR DESCRIPTION
Problem: interrupting `ydbops restart` leaves Requests and Permissions in YDB state.
Sometimes it is desired, so we could continue current instance of rolling restart later (not implemented yet, with --continue flag).

But at other times leaving a high-priority request (not even permission) in YDB state leads to infrastructure teams not being able  to take out nodes for maintenance, EVEN THOUGH the `ydbops restart` process which spawned the request is long gone and does not need this request anymore.