### PR TITLE
Fix maintenance duration with delays

### DIFF
--- a/pkg/rolling/rolling.go
+++ b/pkg/rolling/rolling.go
@@ -190,7 +190,7 @@ func (r *Rolling) DoRestart(ctx context.Context) error {
 	taskParams := cms.MaintenanceTaskParams{
 		TaskUID:          r.state.restartTaskUID,
 		AvailabilityMode: r.opts.GetAvailabilityMode(),
-		Duration:         r.opts.GetRestartDuration(),
+		Duration:         r.opts.GetRestartDuration(len(nodesToRestart)),
 		ScopeType:        cms.NodeScope,
 		Nodes:            nodesToRestart,
 	}

--- a/tests/maintenance_test.go
+++ b/tests/maintenance_test.go
@@ -3,6 +3,7 @@ package tests
 import (
 	"fmt"
 	"path/filepath"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	"github.com/ydb-platform/ydb-go-genproto/draft/protos/Ydb_Maintenance"
@@ -49,7 +50,7 @@ var _ = Describe("Test Maintenance", func() {
 								Description:      "Rolling restart maintenance task",
 								AvailabilityMode: Ydb_Maintenance.AvailabilityMode_AVAILABILITY_MODE_STRONG,
 							},
-							ActionGroups: mock.MakeActionGroupsFromHostFQDNs("ydb-1.ydb.tech", "ydb-2.ydb.tech"),
+							ActionGroups: mock.MakeActionGroupsFromHostFQDNsFixedDuration(time.Second * 180, "ydb-1.ydb.tech", "ydb-2.ydb.tech"),
 						},
 					},
 					expectedOutputRegexps: []string{
@@ -237,7 +238,7 @@ var _ = Describe("Test Maintenance", func() {
 								Description:      "Rolling restart maintenance task",
 								AvailabilityMode: Ydb_Maintenance.AvailabilityMode_AVAILABILITY_MODE_STRONG,
 							},
-							ActionGroups: mock.MakeActionGroupsFromNodeIds(1, 2),
+							ActionGroups: mock.MakeActionGroupsFromNodesIdsFixedDuration(time.Second * 180, 1, 2),
 						},
 					},
 					expectedOutputRegexps: []string{

--- a/tests/mock/cms-nodes.go
+++ b/tests/mock/cms-nodes.go
@@ -36,6 +36,41 @@ func makeNode(nodeID uint32) *Ydb_Maintenance.Node {
 	}
 }
 
+func determineRestartDuration(nNodes int) time.Duration {
+	defaultRestartDuration := time.Second * 60
+	singleBatchRestartTime := defaultRestartDuration * 3
+
+	singleBatchWithWait := singleBatchRestartTime + 1 * time.Second
+	maximumTotalBatches := nNodes
+
+	return time.Duration(maximumTotalBatches) * singleBatchWithWait
+}
+
+func MakeActionGroupsFromNodesIdsFixedDuration(duration time.Duration, nodeIDs ...uint32) []*Ydb_Maintenance.ActionGroup {
+	result := []*Ydb_Maintenance.ActionGroup{}
+	for _, nodeID := range nodeIDs {
+		result = append(result,
+			&Ydb_Maintenance.ActionGroup{
+				Actions: []*Ydb_Maintenance.Action{
+					{
+						Action: &Ydb_Maintenance.Action_LockAction{
+							LockAction: &Ydb_Maintenance.LockAction{
+								Scope: &Ydb_Maintenance.ActionScope{
+									Scope: &Ydb_Maintenance.ActionScope_NodeId{
+										NodeId: nodeID,
+									},
+								},
+								Duration: durationpb.New(duration),
+							},
+						},
+					},
+				},
+			},
+		)
+	}
+	return result
+}
+
 func MakeActionGroupsFromNodeIds(nodeIDs ...uint32) []*Ydb_Maintenance.ActionGroup {
 	result := []*Ydb_Maintenance.ActionGroup{}
 	for _, nodeID := range nodeIDs {
@@ -50,7 +85,32 @@ func MakeActionGroupsFromNodeIds(nodeIDs ...uint32) []*Ydb_Maintenance.ActionGro
 										NodeId: nodeID,
 									},
 								},
-								Duration: durationpb.New(180 * time.Second),
+								Duration: durationpb.New(determineRestartDuration(len(nodeIDs))),
+							},
+						},
+					},
+				},
+			},
+		)
+	}
+	return result
+}
+
+func MakeActionGroupsFromHostFQDNsFixedDuration(duration time.Duration, hostFQDNs ...string) []*Ydb_Maintenance.ActionGroup {
+	result := []*Ydb_Maintenance.ActionGroup{}
+	for _, hostFQDN := range hostFQDNs {
+		result = append(result,
+			&Ydb_Maintenance.ActionGroup{
+				Actions: []*Ydb_Maintenance.Action{
+					{
+						Action: &Ydb_Maintenance.Action_LockAction{
+							LockAction: &Ydb_Maintenance.LockAction{
+								Scope: &Ydb_Maintenance.ActionScope{
+									Scope: &Ydb_Maintenance.ActionScope_Host{
+										Host: hostFQDN,
+									},
+								},
+								Duration: durationpb.New(duration),
 							},
 						},
 					},
@@ -75,7 +135,7 @@ func MakeActionGroupsFromHostFQDNs(hostFQDNs ...string) []*Ydb_Maintenance.Actio
 										Host: hostFQDN,
 									},
 								},
-								Duration: durationpb.New(180 * time.Second),
+								Duration: durationpb.New(determineRestartDuration(len(hostFQDNs))),
 							},
 						},
 					},

--- a/tests/mock/cms-nodes.go
+++ b/tests/mock/cms-nodes.go
@@ -40,7 +40,7 @@ func determineRestartDuration(nNodes int) time.Duration {
 	defaultRestartDuration := time.Second * 60
 	singleBatchRestartTime := defaultRestartDuration * 3
 
-	singleBatchWithWait := singleBatchRestartTime + 1 * time.Second
+	singleBatchWithWait := singleBatchRestartTime + 1*time.Second
 	maximumTotalBatches := nNodes
 
 	return time.Duration(maximumTotalBatches) * singleBatchWithWait


### PR DESCRIPTION
Account for both `--delay-between-restarts` and `--nodes-inflight` when sending the request to CMS. Worst case scenario, CMS will give you all nodes that you asked for, which means that in total the duration must be:

1. Determine base restart duration: reasonable single restart duration * reasonable retry number (currently, 60 and 3)
2. Determine how many batches it will take (total requested nodes / `--nodes-inflight`)
3. Total result will be: number of batches * (base restart duration + `--delay-between-restarts`)