### PR TITLE
Fix restartHandler race during cancellation

### DIFF
--- a/.changes/unreleased/Fixed-20250930-124019.yaml
+++ b/.changes/unreleased/Fixed-20250930-124019.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Race in restartHandler during SIGTERM cancellation
+time: 2025-09-30T12:40:19.649916672+02:00

--- a/pkg/rolling/rolling.go
+++ b/pkg/rolling/rolling.go
@@ -350,6 +350,7 @@ func (r *Rolling) processActionGroupStates(ctx context.Context, actions []*Ydb_M
 
 	statusCh := make(chan restartStatus, r.opts.NodesInflight)
 	restartHandler := newRestartHandler(
+		ctx,
 		r.logger,
 		r.restarter,
 		r.opts.NodesInflight,
@@ -406,7 +407,6 @@ func (r *Rolling) processActionGroupStates(ctx context.Context, actions []*Ydb_M
 	r.state.unreportedButFinishedActionIds = []string{}
 
 	restartCompleted := len(actions) == len(result.ActionStatuses)
-
 	var waitForDelay bool
 	select {
 	case <-ctx.Done():
@@ -414,7 +414,6 @@ func (r *Rolling) processActionGroupStates(ctx context.Context, actions []*Ydb_M
 	default:
 		waitForDelay = !restartCompleted
 	}
-
 	restartHandler.stop(waitForDelay)
 
 	return restartCompleted


### PR DESCRIPTION
Pass a regular ctx.Done channel to restartHanlder instead of relying on a custom `done` channel to trigger cancellation. This allows to avoid a race while pushing an additional work item to the restart queue