### PR TITLE
Better interrupts + node sorting

### DIFF
--- a/.changes/unreleased/Added-20260506-145116.yaml
+++ b/.changes/unreleased/Added-20260506-145116.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: transport level timeout, avoiding stuck grpc connections
+time: 2026-05-06T14:51:16.26024187+02:00

--- a/.changes/unreleased/Added-20260613-160617.yaml
+++ b/.changes/unreleased/Added-20260613-160617.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: Round-robin pre-CMS sort for tenant nodes for effective parallel tenant restart
+time: 2026-06-13T16:06:17.310274161+02:00

--- a/.changes/unreleased/Changed-20260324-173521.yaml
+++ b/.changes/unreleased/Changed-20260324-173521.yaml
@@ -1,0 +1,3 @@
+kind: Changed
+body: ydbops now softly prefers to restart storage nodes from a single failure domain (datacenter + rack)
+time: 2026-03-24T17:35:21.384166047+01:00

--- a/.changes/unreleased/Fixed-20260324-173455.yaml
+++ b/.changes/unreleased/Fixed-20260324-173455.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Interrupt now successfully interrupts retries
+time: 2026-03-24T17:34:55.449371139+01:00

--- a/main.go
+++ b/main.go
@@ -58,7 +58,7 @@ func mainNoExit() error {
 	logLevelSetter, logger := createLogger("info")
 	baseOptions = &command.BaseOptions{}
 	root := cmd.NewRootCommand(logLevelSetter, logger.Sugar(), baseOptions)
-	cf := connectionsfactory.New(baseOptions)
+	cf := connectionsfactory.New(baseOptions, connectionsfactory.DefaultTransportTimeout)
 
 	options.Logger = logger.Sugar() // TODO(shmel1k@): tmp hack
 

--- a/pkg/client/auth/auth.go
+++ b/pkg/client/auth/auth.go
@@ -43,8 +43,12 @@ func (c *defaultAuthClient) executeAuthMethod(
 	if err != nil {
 		return nil, err
 	}
+	defer func() {
+		_ = cc.Close()
+	}()
 
-	ctx := context.TODO() // XXX(shmel1k@): improve context behavior.
+	ctx, cancel := context.WithTimeout(context.Background(), c.f.CallTimeout())
+	defer cancel()
 
 	cl := Ydb_Auth_V1.NewAuthServiceClient(cc)
 	r, err := method(ctx, cl)

--- a/pkg/client/cms/cms.go
+++ b/pkg/client/cms/cms.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ydb-platform/ydb-go-genproto/protos/Ydb_Cms"
 	"github.com/ydb-platform/ydb-go-genproto/protos/Ydb_Operations"
 	"go.uber.org/zap"
+	"google.golang.org/grpc"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/durationpb"
 
@@ -280,53 +281,25 @@ func (c *defaultCMSClient) executeMaintenanceOperation(
 	out proto.Message,
 	method func(context.Context, Ydb_Maintenance_V1.MaintenanceServiceClient) (client.OperationResponse, error),
 ) (*Ydb_Operations.Operation, error) {
-	ctx, cancel := c.credentialsProvider.ContextWithAuth(context.TODO())
-	defer cancel()
-
-	op, err := utils.WrapWithRetries(c.ctx, defaultRetryCount, func() (*Ydb_Operations.Operation, error) {
-		cc, err := c.connectionsFactory.Create()
-		if err != nil {
-			return nil, err
-		}
-		defer func() {
-			_ = cc.Close()
-		}()
-
-		callCtx, cancelTimeout := context.WithTimeout(ctx, c.connectionsFactory.CallTimeout())
-		defer cancelTimeout()
-
+	return c.executeOperation(out, func(ctx context.Context, cc *grpc.ClientConn) (client.OperationResponse, error) {
 		cl := Ydb_Maintenance_V1.NewMaintenanceServiceClient(cc)
-		r, err := method(callCtx, cl)
-		if err != nil {
-			c.logger.Debugf("Invocation error: %+v", err)
-			return nil, err
-		}
-		op := r.GetOperation()
-		utils.LogOperation(c.logger, op)
-		return op, nil
+		return method(ctx, cl)
 	})
-	if err != nil {
-		return nil, err
-	}
-
-	if out == nil {
-		return op, nil
-	}
-
-	if err := op.Result.UnmarshalTo(out); err != nil {
-		return op, err
-	}
-
-	if op.Status != Ydb.StatusIds_SUCCESS {
-		return op, fmt.Errorf("unsuccessful status code: %s", op.Status)
-	}
-
-	return op, nil
 }
 
 func (c *defaultCMSClient) executeCMSOperation(
 	out proto.Message,
 	method func(context.Context, Ydb_Cms_V1.CmsServiceClient) (client.OperationResponse, error),
+) (*Ydb_Operations.Operation, error) {
+	return c.executeOperation(out, func(ctx context.Context, cc *grpc.ClientConn) (client.OperationResponse, error) {
+		cl := Ydb_Cms_V1.NewCmsServiceClient(cc)
+		return method(ctx, cl)
+	})
+}
+
+func (c *defaultCMSClient) executeOperation(
+	out proto.Message,
+	method func(context.Context, *grpc.ClientConn) (client.OperationResponse, error),
 ) (*Ydb_Operations.Operation, error) {
 	ctx, cancel := c.credentialsProvider.ContextWithAuth(context.TODO())
 	defer cancel()
@@ -343,8 +316,7 @@ func (c *defaultCMSClient) executeCMSOperation(
 		callCtx, cancelTimeout := context.WithTimeout(ctx, c.connectionsFactory.CallTimeout())
 		defer cancelTimeout()
 
-		cl := Ydb_Cms_V1.NewCmsServiceClient(cc)
-		r, err := method(callCtx, cl)
+		r, err := method(callCtx, cc)
 		if err != nil {
 			c.logger.Debugf("Invocation error: %+v", err)
 			return nil, err

--- a/pkg/client/cms/cms.go
+++ b/pkg/client/cms/cms.go
@@ -34,10 +34,12 @@ type Client interface {
 	CMS
 	Maintenance
 
+	SetContext(ctx context.Context)
 	Close() error
 }
 
 type defaultCMSClient struct {
+	ctx                 context.Context
 	logger              *zap.SugaredLogger
 	connectionsFactory  connectionsfactory.Factory
 	credentialsProvider credentials.Provider
@@ -49,10 +51,15 @@ func NewCMSClient(
 	cp credentials.Provider,
 ) Client {
 	return &defaultCMSClient{
+		ctx:                 context.Background(),
 		logger:              logger,
 		connectionsFactory:  connectionsFactory,
 		credentialsProvider: cp,
 	}
+}
+
+func (c *defaultCMSClient) SetContext(ctx context.Context) {
+	c.ctx = ctx
 }
 
 func (c *defaultCMSClient) Tenants() ([]string, error) {
@@ -87,30 +94,8 @@ func (c *defaultCMSClient) Nodes() ([]*Ydb_Maintenance.Node, error) {
 		return nil, err
 	}
 
-	for _, node := range result.Nodes {
-		loc := node.GetLocation()
-		if loc == nil || loc.GetDataCenter() == "" || loc.GetRack() == "" {
-			c.logger.Warnf("Node %d (%s) has incomplete location info (dc=%q, rack=%q), "+
-				"rack-aware restart ordering may be suboptimal",
-				node.GetNodeId(), node.GetHost(),
-				loc.GetDataCenter(), loc.GetRack())
-		}
-	}
-
 	nodes := collections.SortBy(result.Nodes,
 		func(l *Ydb_Maintenance.Node, r *Ydb_Maintenance.Node) bool {
-			lLoc, rLoc := l.GetLocation(), r.GetLocation()
-			if lLoc == nil || rLoc == nil {
-				return l.NodeId < r.NodeId
-			}
-			lDC, rDC := lLoc.GetDataCenter(), rLoc.GetDataCenter()
-			if lDC != rDC {
-				return lDC < rDC
-			}
-			lRack, rRack := lLoc.GetRack(), rLoc.GetRack()
-			if lRack != rRack {
-				return lRack < rRack
-			}
 			return l.NodeId < r.NodeId
 		},
 	)
@@ -299,7 +284,7 @@ func (c *defaultCMSClient) executeMaintenanceOperation(
 	ctx, cancel := c.credentialsProvider.ContextWithAuth(context.TODO())
 	defer cancel()
 
-	op, err := utils.WrapWithRetries(defaultRetryCount, func() (*Ydb_Operations.Operation, error) {
+	op, err := utils.WrapWithRetries(c.ctx, defaultRetryCount, func() (*Ydb_Operations.Operation, error) {
 		cc, err := c.connectionsFactory.Create()
 		if err != nil {
 			return nil, err
@@ -344,7 +329,7 @@ func (c *defaultCMSClient) executeCMSOperation(
 	ctx, cancel := c.credentialsProvider.ContextWithAuth(context.TODO())
 	defer cancel()
 
-	op, err := utils.WrapWithRetries(defaultRetryCount, func() (*Ydb_Operations.Operation, error) {
+	op, err := utils.WrapWithRetries(c.ctx, defaultRetryCount, func() (*Ydb_Operations.Operation, error) {
 		cc, err := c.connectionsFactory.Create()
 		if err != nil {
 			return nil, err

--- a/pkg/client/cms/cms.go
+++ b/pkg/client/cms/cms.go
@@ -87,8 +87,30 @@ func (c *defaultCMSClient) Nodes() ([]*Ydb_Maintenance.Node, error) {
 		return nil, err
 	}
 
+	for _, node := range result.Nodes {
+		loc := node.GetLocation()
+		if loc == nil || loc.GetDataCenter() == "" || loc.GetRack() == "" {
+			c.logger.Warnf("Node %d (%s) has incomplete location info (dc=%q, rack=%q), "+
+				"rack-aware restart ordering may be suboptimal",
+				node.GetNodeId(), node.GetHost(),
+				loc.GetDataCenter(), loc.GetRack())
+		}
+	}
+
 	nodes := collections.SortBy(result.Nodes,
 		func(l *Ydb_Maintenance.Node, r *Ydb_Maintenance.Node) bool {
+			lLoc, rLoc := l.GetLocation(), r.GetLocation()
+			if lLoc == nil || rLoc == nil {
+				return l.NodeId < r.NodeId
+			}
+			lDC, rDC := lLoc.GetDataCenter(), rLoc.GetDataCenter()
+			if lDC != rDC {
+				return lDC < rDC
+			}
+			lRack, rRack := lLoc.GetRack(), rLoc.GetRack()
+			if lRack != rRack {
+				return lRack < rRack
+			}
 			return l.NodeId < r.NodeId
 		},
 	)

--- a/pkg/client/cms/cms.go
+++ b/pkg/client/cms/cms.go
@@ -205,7 +205,6 @@ func (c *defaultCMSClient) CreateMaintenanceTask(params MaintenanceTaskParams) (
 		},
 	}
 
-	fmt.Println(params.Duration)
 	if params.ScopeType == NodeScope {
 		request.ActionGroups = actionGroupsFromNodes(params)
 	} else { // HostScope
@@ -293,8 +292,11 @@ func (c *defaultCMSClient) executeMaintenanceOperation(
 			_ = cc.Close()
 		}()
 
+		callCtx, cancelTimeout := context.WithTimeout(ctx, c.connectionsFactory.CallTimeout())
+		defer cancelTimeout()
+
 		cl := Ydb_Maintenance_V1.NewMaintenanceServiceClient(cc)
-		r, err := method(ctx, cl)
+		r, err := method(callCtx, cl)
 		if err != nil {
 			c.logger.Debugf("Invocation error: %+v", err)
 			return nil, err
@@ -334,9 +336,15 @@ func (c *defaultCMSClient) executeCMSOperation(
 		if err != nil {
 			return nil, err
 		}
+		defer func() {
+			_ = cc.Close()
+		}()
+
+		callCtx, cancelTimeout := context.WithTimeout(ctx, c.connectionsFactory.CallTimeout())
+		defer cancelTimeout()
 
 		cl := Ydb_Cms_V1.NewCmsServiceClient(cc)
-		r, err := method(ctx, cl)
+		r, err := method(callCtx, cl)
 		if err != nil {
 			c.logger.Debugf("Invocation error: %+v", err)
 			return nil, err

--- a/pkg/client/cms/suite_test.go
+++ b/pkg/client/cms/suite_test.go
@@ -1,0 +1,13 @@
+package cms_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestCMS(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "CMS Suite")
+}

--- a/pkg/client/cms/timeout_test.go
+++ b/pkg/client/cms/timeout_test.go
@@ -1,0 +1,105 @@
+package cms_test
+
+import (
+	"context"
+	"net"
+	"strconv"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/ydb-platform/ydb-go-genproto/draft/Ydb_Maintenance_V1"
+	"github.com/ydb-platform/ydb-go-genproto/draft/protos/Ydb_Maintenance"
+	"go.uber.org/zap"
+	"google.golang.org/grpc"
+
+	"github.com/ydb-platform/ydbops/pkg/client/auth/credentials"
+	"github.com/ydb-platform/ydbops/pkg/client/cms"
+	"github.com/ydb-platform/ydbops/pkg/client/connectionsfactory"
+	"github.com/ydb-platform/ydbops/pkg/command"
+	"github.com/ydb-platform/ydbops/pkg/options"
+)
+
+type hangingMaintenanceServer struct {
+	Ydb_Maintenance_V1.UnimplementedMaintenanceServiceServer
+}
+
+func (*hangingMaintenanceServer) CreateMaintenanceTask(
+	ctx context.Context,
+	_ *Ydb_Maintenance.CreateMaintenanceTaskRequest,
+) (*Ydb_Maintenance.MaintenanceTaskResponse, error) {
+	// We avoid replying until timeout runs out. From the client perspective,
+	// this is equivalent to stuck TCP connection, so we can test L3 level timeout
+	// this way.
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
+var _ = Describe("CMS client deadline", func() {
+	// this test could have been an e2e test as most our tests, but it relies on overriding
+	// timeout values for quicker test (still cant use fake clock though), so we need to call
+	// functions directly -> integration test instead
+	It("aborts a stuck CreateMaintenanceTask at the per-call deadline", func() {
+		lis, err := net.Listen("tcp", "127.0.0.1:0")
+		Expect(err).NotTo(HaveOccurred())
+
+		srv := grpc.NewServer()
+		Ydb_Maintenance_V1.RegisterMaintenanceServiceServer(srv, &hangingMaintenanceServer{})
+		go func() { _ = srv.Serve(lis) }()
+		DeferCleanup(srv.Stop)
+
+		host, portStr, err := net.SplitHostPort(lis.Addr().String())
+		Expect(err).NotTo(HaveOccurred())
+		port, err := strconv.Atoi(portStr)
+		Expect(err).NotTo(HaveOccurred())
+
+		baseOpts := &command.BaseOptions{
+			GRPC: options.GRPC{
+				Endpoint:       host,
+				GRPCPort:       port,
+				GRPCSecure:     false,
+				TimeoutSeconds: 0, // this is a YDB OperationTimeout, does not make sense for this test as our mock does not use it
+			},
+			Auth: options.AuthOptions{
+				Type:  options.IamToken,
+				Creds: &options.AuthIAMToken{Token: "fake"},
+			},
+		}
+		factory := connectionsfactory.New(baseOpts, 200*time.Millisecond)
+		creds := credentials.New(baseOpts, factory, zap.NewNop().Sugar(), nil)
+		client := cms.NewCMSClient(factory, zap.NewNop().Sugar(), creds)
+		DeferCleanup(client.Close)
+
+		// Setting a global timeout for this test:
+		// we have request + 200ms timeout + one second (default) backoff retry + another 200ms timeout
+		// this fits in 1.5 seconds nicely
+		bounded, cancel := context.WithTimeout(context.Background(), 1500*time.Millisecond)
+		defer cancel()
+		client.SetContext(bounded)
+
+		// to check if the call is stuck, we need to run the actual test in a
+		// separate goroutine and check on deadline expiration
+		type callResult struct {
+			err     error
+			elapsed time.Duration
+		}
+		done := make(chan callResult, 1)
+		start := time.Now()
+		go func() {
+			_, err := client.CreateMaintenanceTask(cms.MaintenanceTaskParams{
+				TaskUID:   "deadline-test",
+				ScopeType: cms.NodeScope,
+				Nodes:     []*Ydb_Maintenance.Node{{NodeId: 1}},
+			})
+			done <- callResult{err: err, elapsed: time.Since(start)}
+		}()
+
+		select {
+		case r := <-done:
+			Expect(r.err).To(HaveOccurred())
+			GinkgoT().Logf("CreateMaintenanceTask returned %v after %v", r.err, r.elapsed)
+		case <-time.After(2 * time.Second):
+			Fail("CreateMaintenanceTask expected to return within 1.5 seconds but still didn't return after 2 seconds")
+		}
+	})
+})

--- a/pkg/client/connectionsfactory/connections_factory.go
+++ b/pkg/client/connectionsfactory/connections_factory.go
@@ -11,6 +11,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/keepalive"
 	"google.golang.org/protobuf/types/known/durationpb"
 
 	"github.com/ydb-platform/ydbops/pkg/command"
@@ -18,32 +19,49 @@ import (
 
 const (
 	BufferSize = 32 << 20
+
+	// This gets added on top of OperationTimeout, so grpc call can terminate
+	// if any transport layer errors occur. Without this timeout, we wait forever
+	// inside retry loop, not completing a single request
+	DefaultTransportTimeout = 10 * time.Second
 )
 
 type Factory interface {
 	Create() (*grpc.ClientConn, error)
 	OperationParams() *Ydb_Operations.OperationParams
+	OperationTimeout() time.Duration
+	CallTimeout() time.Duration
 }
 
 func New(
 	options *command.BaseOptions,
+	transportTimeout time.Duration,
 ) Factory {
 	return &connectionsFactory{
-		options: options,
+		options:          options,
+		transportTimeout: transportTimeout,
 	}
 }
 
 type connectionsFactory struct {
-	options *command.BaseOptions
+	options          *command.BaseOptions
+	transportTimeout time.Duration
 }
 
-// OperationParams implements Factory.
 func (f *connectionsFactory) OperationParams() *Ydb_Operations.OperationParams {
 	return &Ydb_Operations.OperationParams{
 		OperationMode:    Ydb_Operations.OperationParams_SYNC,
-		OperationTimeout: durationpb.New(time.Duration(f.options.GRPC.TimeoutSeconds) * time.Second),
-		CancelAfter:      durationpb.New(time.Duration(f.options.GRPC.TimeoutSeconds) * time.Second),
+		OperationTimeout: durationpb.New(f.OperationTimeout()),
+		CancelAfter:      durationpb.New(f.OperationTimeout()),
 	}
+}
+
+func (f *connectionsFactory) OperationTimeout() time.Duration {
+	return time.Duration(f.options.GRPC.TimeoutSeconds) * time.Second
+}
+
+func (f *connectionsFactory) CallTimeout() time.Duration {
+	return f.OperationTimeout() + f.transportTimeout
 }
 
 func (f *connectionsFactory) Create() (*grpc.ClientConn, error) {
@@ -58,6 +76,11 @@ func (f *connectionsFactory) Create() (*grpc.ClientConn, error) {
 
 	return grpc.Dial(f.endpoint(),
 		grpc.WithTransportCredentials(cr),
+		grpc.WithKeepaliveParams(keepalive.ClientParameters{
+			Time:                30 * time.Second,
+			Timeout:             10 * time.Second,
+			PermitWithoutStream: false,
+		}),
 		grpc.WithDefaultCallOptions(
 			grpc.MaxCallSendMsgSize(BufferSize),
 			grpc.MaxCallRecvMsgSize(BufferSize)))

--- a/pkg/client/discovery/discovery.go
+++ b/pkg/client/discovery/discovery.go
@@ -84,6 +84,9 @@ func (c *Discovery) ExecuteDiscoveryMethod(
 	ctx, cancel := c.credentialsProvider.ContextWithAuth(context.TODO())
 	defer cancel()
 
+	ctx, cancelTimeout := context.WithTimeout(ctx, c.connectionsFactory.CallTimeout())
+	defer cancelTimeout()
+
 	cl := Ydb_Discovery_V1.NewDiscoveryServiceClient(cc)
 	r, err := method(ctx, cl)
 	if err != nil {

--- a/pkg/rolling/restarters/primitives.go
+++ b/pkg/rolling/restarters/primitives.go
@@ -209,7 +209,12 @@ func SortByRackLocation(nodes []*Ydb_Maintenance.Node, logger *zap.SugaredLogger
 		}
 	}
 	if allDynamic {
-		return nodes
+		// Get stable node order even without location info.
+		return collections.SortBy(nodes,
+			func(l *Ydb_Maintenance.Node, r *Ydb_Maintenance.Node) bool {
+				return l.NodeId < r.NodeId
+			},
+		)
 	}
 
 	for _, node := range nodes {

--- a/pkg/rolling/restarters/primitives.go
+++ b/pkg/rolling/restarters/primitives.go
@@ -213,6 +213,11 @@ func SortByRackLocation(nodes []*Ydb_Maintenance.Node, logger *zap.SugaredLogger
 	}
 
 	for _, node := range nodes {
+		// for dynnodes, we do not have rack awareness during restarts.
+		// we therefore don't need warnings about dynnodes not having location info (they never have it anyway)
+		if node.GetDynamic() != nil {
+			continue
+		}
 		loc := node.GetLocation()
 		if loc == nil || loc.GetDataCenter() == "" || loc.GetRack() == "" {
 			logger.Warnf("Node %d (%s) has incomplete location info (dc=%q, rack=%q), "+

--- a/pkg/rolling/restarters/primitives.go
+++ b/pkg/rolling/restarters/primitives.go
@@ -200,6 +200,47 @@ func ExcludeByTenantNames(
 	})
 }
 
+func SortByRackLocation(nodes []*Ydb_Maintenance.Node, logger *zap.SugaredLogger) []*Ydb_Maintenance.Node {
+	allDynamic := true
+	for _, node := range nodes {
+		if node.GetDynamic() == nil {
+			allDynamic = false
+			break
+		}
+	}
+	if allDynamic {
+		return nodes
+	}
+
+	for _, node := range nodes {
+		loc := node.GetLocation()
+		if loc == nil || loc.GetDataCenter() == "" || loc.GetRack() == "" {
+			logger.Warnf("Node %d (%s) has incomplete location info (dc=%q, rack=%q), "+
+				"rack-aware restart ordering may be suboptimal",
+				node.GetNodeId(), node.GetHost(),
+				loc.GetDataCenter(), loc.GetRack())
+		}
+	}
+
+	return collections.SortBy(nodes,
+		func(l *Ydb_Maintenance.Node, r *Ydb_Maintenance.Node) bool {
+			lLoc, rLoc := l.GetLocation(), r.GetLocation()
+			if lLoc == nil || rLoc == nil {
+				return l.NodeId < r.NodeId
+			}
+			lDC, rDC := lLoc.GetDataCenter(), rLoc.GetDataCenter()
+			if lDC != rDC {
+				return lDC < rDC
+			}
+			lRack, rRack := lLoc.GetRack(), rLoc.GetRack()
+			if lRack != rRack {
+				return lRack < rRack
+			}
+			return l.NodeId < r.NodeId
+		},
+	)
+}
+
 func MergeAndUnique(nodeSlices ...[]*Ydb_Maintenance.Node) []*Ydb_Maintenance.Node {
 	presentNodes := make(map[uint32]bool)
 	result := []*Ydb_Maintenance.Node{}

--- a/pkg/rolling/rolling.go
+++ b/pkg/rolling/rolling.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/signal"
 	"slices"
+	"sort"
 	"strings"
 	"sync"
 	"syscall"
@@ -175,7 +176,7 @@ func (r *Rolling) DoRestart(ctx context.Context) error {
 		},
 	)
 
-	nodesToRestart = restarters.SortByRackLocation(nodesToRestart, r.logger)
+	nodesToRestart = r.orderNodesForRestart(nodesToRestart)
 
 	excludedNodes := 0
 	for _, node := range nodesToRestart {
@@ -211,6 +212,43 @@ func (r *Rolling) DoRestart(ctx context.Context) error {
 	r.state.totalFilteredNodes = len(nodesToRestart)
 
 	return r.cmsWaitingLoop(ctx, task)
+}
+
+func (r *Rolling) orderNodesForRestart(nodes []*Ydb_Maintenance.Node) []*Ydb_Maintenance.Node {
+	if r.opts.TenantsInflight > 0 && len(nodes) > 0 && nodes[0].GetDynamic() != nil {
+		r.logger.Debugf("ordering tenant nodes by tenant round-robin")
+		return orderTenantNodesRoundRobin(nodes)
+	}
+
+	return restarters.SortByRackLocation(nodes, r.logger)
+}
+
+func orderTenantNodesRoundRobin(nodes []*Ydb_Maintenance.Node) []*Ydb_Maintenance.Node {
+	sortedNodes := slices.Clone(nodes)
+	sort.Slice(sortedNodes, func(i, j int) bool {
+		return sortedNodes[i].GetNodeId() < sortedNodes[j].GetNodeId()
+	})
+
+	groups := make(map[string][]*Ydb_Maintenance.Node)
+	tenants := make([]string, 0)
+	for _, node := range sortedNodes {
+		tenant := node.GetDynamic().GetTenant()
+		if _, exists := groups[tenant]; !exists {
+			tenants = append(tenants, tenant)
+		}
+		groups[tenant] = append(groups[tenant], node)
+	}
+
+	ordered := make([]*Ydb_Maintenance.Node, 0, len(nodes))
+	for round := 0; len(ordered) < len(nodes); round++ {
+		for _, tenant := range tenants {
+			if round < len(groups[tenant]) {
+				ordered = append(ordered, groups[tenant][round])
+			}
+		}
+	}
+
+	return ordered
 }
 
 func (r *Rolling) cmsWaitingLoop(ctx context.Context, task cms.MaintenanceTask) error {

--- a/pkg/rolling/rolling.go
+++ b/pkg/rolling/rolling.go
@@ -114,6 +114,8 @@ func (e *executer) Execute() error {
 		}()
 	}
 
+	r.cms.SetContext(ctx)
+
 	e.logger.Info("Start rolling restart")
 	err := r.DoRestart(ctx)
 
@@ -172,6 +174,8 @@ func (r *Rolling) DoRestart(ctx context.Context) error {
 			AllNodes:        collections.Values(r.state.nodes),
 		},
 	)
+
+	nodesToRestart = restarters.SortByRackLocation(nodesToRestart, r.logger)
 
 	excludedNodes := 0
 	for _, node := range nodesToRestart {

--- a/pkg/rolling/rolling_test.go
+++ b/pkg/rolling/rolling_test.go
@@ -1,12 +1,18 @@
 package rolling
 
 import (
-	"reflect"
 	"testing"
 
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	"github.com/ydb-platform/ydb-go-genproto/draft/protos/Ydb_Maintenance"
 	"go.uber.org/zap"
 )
+
+func TestRolling(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Rolling Suite")
+}
 
 func testTenantNode(nodeID uint32, tenant string) *Ydb_Maintenance.Node {
 	return &Ydb_Maintenance.Node{
@@ -27,44 +33,40 @@ func nodeIDs(nodes []*Ydb_Maintenance.Node) []uint32 {
 	return ids
 }
 
-func TestOrderTenantNodesRoundRobin(t *testing.T) {
-	nodes := []*Ydb_Maintenance.Node{
-		testTenantNode(1, "tenant-a"),
-		testTenantNode(2, "tenant-a"),
-		testTenantNode(3, "tenant-a"),
-		testTenantNode(10, "tenant-b"),
-		testTenantNode(11, "tenant-b"),
-		testTenantNode(20, "tenant-c"),
-	}
+var _ = Describe("Tenant restart node ordering", func() {
+	It("round-robins tenant nodes after sorting by node id", func() {
+		nodes := []*Ydb_Maintenance.Node{
+			testTenantNode(1, "tenant-a"),
+			testTenantNode(2, "tenant-a"),
+			testTenantNode(3, "tenant-a"),
+			testTenantNode(10, "tenant-b"),
+			testTenantNode(11, "tenant-b"),
+			testTenantNode(20, "tenant-c"),
+		}
 
-	ordered := orderTenantNodesRoundRobin(nodes)
-	expected := []uint32{1, 10, 20, 2, 11, 3}
+		ordered := orderTenantNodesRoundRobin(nodes)
 
-	if !reflect.DeepEqual(nodeIDs(ordered), expected) {
-		t.Fatalf("unexpected tenant round-robin order: got %v, want %v", nodeIDs(ordered), expected)
-	}
-}
+		Expect(nodeIDs(ordered)).To(Equal([]uint32{1, 10, 20, 2, 11, 3}))
+	})
 
-func TestOrderNodesForRestartUsesTenantRoundRobinWithTenantsInflight(t *testing.T) {
-	rolling := &Rolling{
-		logger: zap.NewNop().Sugar(),
-		opts: &RestartOptions{
-			TenantsInflight: 10,
-		},
-	}
-	nodes := []*Ydb_Maintenance.Node{
-		testTenantNode(1, "tenant-a"),
-		testTenantNode(2, "tenant-a"),
-		testTenantNode(3, "tenant-a"),
-		testTenantNode(10, "tenant-b"),
-		testTenantNode(11, "tenant-b"),
-		testTenantNode(20, "tenant-c"),
-	}
+	It("uses tenant round-robin for restart ordering when tenants-inflight is set", func() {
+		rolling := &Rolling{
+			logger: zap.NewNop().Sugar(),
+			opts: &RestartOptions{
+				TenantsInflight: 10,
+			},
+		}
+		nodes := []*Ydb_Maintenance.Node{
+			testTenantNode(1, "tenant-a"),
+			testTenantNode(2, "tenant-a"),
+			testTenantNode(3, "tenant-a"),
+			testTenantNode(10, "tenant-b"),
+			testTenantNode(11, "tenant-b"),
+			testTenantNode(20, "tenant-c"),
+		}
 
-	ordered := rolling.orderNodesForRestart(nodes)
-	expected := []uint32{1, 10, 20, 2, 11, 3}
+		ordered := rolling.orderNodesForRestart(nodes)
 
-	if !reflect.DeepEqual(nodeIDs(ordered), expected) {
-		t.Fatalf("unexpected restart node order: got %v, want %v", nodeIDs(ordered), expected)
-	}
-}
+		Expect(nodeIDs(ordered)).To(Equal([]uint32{1, 10, 20, 2, 11, 3}))
+	})
+})

--- a/pkg/rolling/rolling_test.go
+++ b/pkg/rolling/rolling_test.go
@@ -1,0 +1,70 @@
+package rolling
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/ydb-platform/ydb-go-genproto/draft/protos/Ydb_Maintenance"
+	"go.uber.org/zap"
+)
+
+func testTenantNode(nodeID uint32, tenant string) *Ydb_Maintenance.Node {
+	return &Ydb_Maintenance.Node{
+		NodeId: nodeID,
+		Type: &Ydb_Maintenance.Node_Dynamic{
+			Dynamic: &Ydb_Maintenance.Node_DynamicNode{
+				Tenant: tenant,
+			},
+		},
+	}
+}
+
+func nodeIDs(nodes []*Ydb_Maintenance.Node) []uint32 {
+	ids := make([]uint32, 0, len(nodes))
+	for _, node := range nodes {
+		ids = append(ids, node.GetNodeId())
+	}
+	return ids
+}
+
+func TestOrderTenantNodesRoundRobin(t *testing.T) {
+	nodes := []*Ydb_Maintenance.Node{
+		testTenantNode(1, "tenant-a"),
+		testTenantNode(2, "tenant-a"),
+		testTenantNode(3, "tenant-a"),
+		testTenantNode(10, "tenant-b"),
+		testTenantNode(11, "tenant-b"),
+		testTenantNode(20, "tenant-c"),
+	}
+
+	ordered := orderTenantNodesRoundRobin(nodes)
+	expected := []uint32{1, 10, 20, 2, 11, 3}
+
+	if !reflect.DeepEqual(nodeIDs(ordered), expected) {
+		t.Fatalf("unexpected tenant round-robin order: got %v, want %v", nodeIDs(ordered), expected)
+	}
+}
+
+func TestOrderNodesForRestartUsesTenantRoundRobinWithTenantsInflight(t *testing.T) {
+	rolling := &Rolling{
+		logger: zap.NewNop().Sugar(),
+		opts: &RestartOptions{
+			TenantsInflight: 10,
+		},
+	}
+	nodes := []*Ydb_Maintenance.Node{
+		testTenantNode(1, "tenant-a"),
+		testTenantNode(2, "tenant-a"),
+		testTenantNode(3, "tenant-a"),
+		testTenantNode(10, "tenant-b"),
+		testTenantNode(11, "tenant-b"),
+		testTenantNode(20, "tenant-c"),
+	}
+
+	ordered := rolling.orderNodesForRestart(nodes)
+	expected := []uint32{1, 10, 20, 2, 11, 3}
+
+	if !reflect.DeepEqual(nodeIDs(ordered), expected) {
+		t.Fatalf("unexpected restart node order: got %v, want %v", nodeIDs(ordered), expected)
+	}
+}

--- a/pkg/utils/retries.go
+++ b/pkg/utils/retries.go
@@ -36,8 +36,7 @@ func backoffTimeAfter(attempt int) time.Duration {
 }
 
 func shouldRetry(code codes.Code) bool {
-	// TODO what other error codes?
-	return code == codes.Unavailable
+	return code == codes.Unavailable || code == codes.DeadlineExceeded
 }
 
 func isRetryableStatus(status Ydb.StatusIds_StatusCode) bool {

--- a/pkg/utils/retries.go
+++ b/pkg/utils/retries.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"context"
 	"fmt"
 	"math"
 	"time"
@@ -45,6 +46,7 @@ func isRetryableStatus(status Ydb.StatusIds_StatusCode) bool {
 }
 
 func WrapWithRetries(
+	ctx context.Context,
 	maxAttempts int,
 	f func() (*Ydb_Operations.Operation, error),
 ) (*Ydb_Operations.Operation, error) {
@@ -66,7 +68,11 @@ func WrapWithRetries(
 			delay := backoffTimeAfter(attempt)
 			if attempt < maxAttempts-1 {
 				zap.S().Debugf("Retrying after %v seconds...\n", delay.Seconds())
-				time.Sleep(delay)
+				select {
+				case <-ctx.Done():
+					return nil, ctx.Err()
+				case <-time.After(delay):
+				}
 			}
 			lastError = err
 		} else {

--- a/pkg/utils/retries_test.go
+++ b/pkg/utils/retries_test.go
@@ -159,4 +159,31 @@ var _ = Describe("WrapWithRetries", func() {
 			Expect(elapsed).To(BeNumerically(">=", time.Second))
 		})
 	})
+
+	Describe("Context cancellation during backoff", func() {
+		It("aborts retries and returns ctx.Err()", func() {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			callCount := 0
+			// Cancel shortly after the first attempt returns, while we are
+			// sleeping in backoff (backoff[0] = 1s, so 100ms gives us margin).
+			go func() {
+				time.Sleep(100 * time.Millisecond)
+				cancel()
+			}()
+
+			start := time.Now()
+			result, err := WrapWithRetries(ctx, 5, func() (*Ydb_Operations.Operation, error) {
+				callCount++
+				return nil, status.Error(codes.Unavailable, "unavailable")
+			})
+			elapsed := time.Since(start)
+
+			Expect(err).To(MatchError(context.Canceled))
+			Expect(result).To(BeNil())
+			Expect(callCount).To(Equal(1))
+			Expect(elapsed).To(BeNumerically("<", time.Second))
+		})
+	})
 })

--- a/pkg/utils/retries_test.go
+++ b/pkg/utils/retries_test.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"context"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -29,7 +30,7 @@ var _ = Describe("WrapWithRetries", func() {
 			callCount := 0
 			op := &Ydb_Operations.Operation{Status: Ydb.StatusIds_SUCCESS}
 
-			result, err := WrapWithRetries(3, func() (*Ydb_Operations.Operation, error) {
+			result, err := WrapWithRetries(context.Background(), 3, func() (*Ydb_Operations.Operation, error) {
 				callCount++
 				return op, nil
 			})
@@ -45,7 +46,7 @@ var _ = Describe("WrapWithRetries", func() {
 			callCount := 0
 			expectedErr := status.Error(codes.Internal, "internal error")
 
-			result, err := WrapWithRetries(3, func() (*Ydb_Operations.Operation, error) {
+			result, err := WrapWithRetries(context.Background(), 3, func() (*Ydb_Operations.Operation, error) {
 				callCount++
 				return nil, expectedErr
 			})
@@ -61,7 +62,7 @@ var _ = Describe("WrapWithRetries", func() {
 			callCount := 0
 			successOp := &Ydb_Operations.Operation{Status: Ydb.StatusIds_SUCCESS}
 
-			result, err := WrapWithRetries(5, func() (*Ydb_Operations.Operation, error) {
+			result, err := WrapWithRetries(context.Background(), 5, func() (*Ydb_Operations.Operation, error) {
 				callCount++
 				if callCount < 3 {
 					return nil, status.Error(codes.Unavailable, "unavailable")
@@ -78,7 +79,7 @@ var _ = Describe("WrapWithRetries", func() {
 			callCount := 0
 			expectedErr := status.Error(codes.Unavailable, "unavailable")
 
-			result, err := WrapWithRetries(3, func() (*Ydb_Operations.Operation, error) {
+			result, err := WrapWithRetries(context.Background(), 3, func() (*Ydb_Operations.Operation, error) {
 				callCount++
 				return nil, expectedErr
 			})
@@ -96,7 +97,7 @@ var _ = Describe("WrapWithRetries", func() {
 			unavailableOp := &Ydb_Operations.Operation{Status: Ydb.StatusIds_UNAVAILABLE}
 			successOp := &Ydb_Operations.Operation{Status: Ydb.StatusIds_SUCCESS}
 
-			result, err := WrapWithRetries(5, func() (*Ydb_Operations.Operation, error) {
+			result, err := WrapWithRetries(context.Background(), 5, func() (*Ydb_Operations.Operation, error) {
 				callCount++
 				if callCount < 3 {
 					return unavailableOp, nil
@@ -113,7 +114,7 @@ var _ = Describe("WrapWithRetries", func() {
 			callCount := 0
 			unavailableOp := &Ydb_Operations.Operation{Status: Ydb.StatusIds_UNAVAILABLE}
 
-			result, err := WrapWithRetries(3, func() (*Ydb_Operations.Operation, error) {
+			result, err := WrapWithRetries(context.Background(), 3, func() (*Ydb_Operations.Operation, error) {
 				callCount++
 				return unavailableOp, nil
 			})
@@ -130,7 +131,7 @@ var _ = Describe("WrapWithRetries", func() {
 			callCount := 0
 			badRequestOp := &Ydb_Operations.Operation{Status: Ydb.StatusIds_BAD_REQUEST}
 
-			result, err := WrapWithRetries(3, func() (*Ydb_Operations.Operation, error) {
+			result, err := WrapWithRetries(context.Background(), 3, func() (*Ydb_Operations.Operation, error) {
 				callCount++
 				return badRequestOp, nil
 			})
@@ -145,7 +146,7 @@ var _ = Describe("WrapWithRetries", func() {
 		It("should sleep between retries", func() {
 			callCount := 0
 			start := time.Now()
-			result, err := WrapWithRetries(2, func() (*Ydb_Operations.Operation, error) {
+			result, err := WrapWithRetries(context.Background(), 2, func() (*Ydb_Operations.Operation, error) {
 				callCount++
 				return nil, status.Error(codes.Unavailable, "unavailable")
 			})


### PR DESCRIPTION
Several quality of life changes:

- [bugfix] add transport-layer timeouts to avoid stuck grpc connections
- [bugfix] ctrl+c now interrupts correctly (previously not all points were interruptible and that led to delays depending on parameters, up to 30s with defaults)
- [no-config feature] an attempt to optimize per-tenant restart: assuming that CMS tries to give nodes in the order of submission, sorting round-robin by tenants gave a speedup (it was actually considered back when per tenant restart was implemented but due to human error didnt go into https://github.com/ydb-platform/ydbops/pull/81 previous PR)
- [no-config feature] soft-prefer to restart nodes from a single failure domain (compared to just strict node-id sorting)
- new tests for all the above