### PR TITLE
Add database context to YDB requests

### DIFF
--- a/.changes/unreleased/Fixed-20260818-140020.yaml
+++ b/.changes/unreleased/Fixed-20260818-140020.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Send the selected database in gRPC metadata so database-scoped YDB endpoints accept maintenance requests
+time: 2026-08-18T14:00:20+03:00

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Please browse the `ydbops --help` first. Then read along for examples (substitut
 ```
 ydbops restart --storage \
   --endpoint grpc://<cluster-fqdn> \
+  --database /Root \
   --ssh-args=pssh,-A,-J,<bastion-fqdn>,--ycp-profile,prod,--no-yubikey \
   --verbose --hosts=<node1-fqdn>,<node2-fqdn>,<node3-fqdn>
 ```
@@ -22,6 +23,7 @@ ydbops restart --storage \
 ```
 ydbops restart --storage \
   --endpoint grpc://<cluster-fqdn> \
+  --database /Root \
   --ssh-args=pssh,-A,-J,<bastion-fqdn>,--ycp-profile,prod,--no-yubikey \
   --verbose
 ```
@@ -31,6 +33,7 @@ ydbops restart --storage \
 ```
 ydbops run \
   --endpoint grpc://<cluster-fqdn> \
+  --database /Root \
   --availability-mode strong --verbose --hosts=7,8 \
   --payload ./tests/payloads/payload-echo-helloworld.sh
 ```
@@ -40,6 +43,7 @@ ydbops run \
 ```
 ydbops run \
   --endpoint grpc://<cluster-fqdn> \
+  --database /Root \
   --availability-mode strong --verbose --hosts=5,6 \
   --payload ./tests/payloads/payload-restart-ydbd.sh
 ```
@@ -52,6 +56,7 @@ An example of authenticating with static credentials:
 export YDB_PASSWORD=password_123
 ydbops restart --storage \
   --endpoint grpc://<cluster-fqdn> \
+  --database /Root \
   --availability-mode strong --verbose --hosts=7,8 \
   --user jorres --kubeconfig ~/.kube/config
 ```
@@ -66,6 +71,7 @@ And this will make sure to not restart nodes from more than 2 tenants at the sam
 export YDB_PASSWORD=password_123
 ydbops restart --tenant \
   --endpoint grpc://<cluster-fqdn> \
+  --database /Root \
   --availability-mode strong --verbose --hosts=7,8 \
   --user jorres --kubeconfig ~/.kube/config \
   --nodes-inflight 3 \

--- a/main.go
+++ b/main.go
@@ -62,6 +62,7 @@ func mainNoExit() error {
 	cf := connectionsfactory.NewFromDelayedConfig(func() connectionsfactory.Config {
 		return connectionsfactory.Config{
 			Endpoint:         baseOptions.GRPC.Endpoint,
+			Database:         baseOptions.GRPC.Database,
 			GRPCPort:         baseOptions.GRPC.GRPCPort,
 			GRPCSecure:       baseOptions.GRPC.GRPCSecure,
 			GRPCSkipVerify:   baseOptions.GRPC.GRPCSkipVerify,

--- a/pkg/client/connectionsfactory/connections_factory.go
+++ b/pkg/client/connectionsfactory/connections_factory.go
@@ -1,6 +1,7 @@
 package connectionsfactory
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
@@ -12,11 +13,13 @@ import (
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/keepalive"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/protobuf/types/known/durationpb"
 )
 
 const (
-	BufferSize = 32 << 20
+	BufferSize     = 32 << 20
+	databaseHeader = "x-ydb-database"
 
 	// This gets added on top of OperationTimeout, so grpc call can terminate
 	// if any transport layer errors occur. Without this timeout, we wait forever
@@ -33,6 +36,7 @@ type Factory interface {
 
 type Config struct {
 	Endpoint         string
+	Database         string
 	GRPCPort         int
 	GRPCSecure       bool
 	GRPCSkipVerify   bool
@@ -86,6 +90,7 @@ func (f *connectionsFactory) Create() (*grpc.ClientConn, error) {
 
 	return grpc.Dial(endpoint(config),
 		grpc.WithTransportCredentials(cr),
+		grpc.WithUnaryInterceptor(databaseUnaryInterceptor(config.Database)),
 		grpc.WithKeepaliveParams(keepalive.ClientParameters{
 			Time:                30 * time.Second,
 			Timeout:             10 * time.Second,
@@ -94,6 +99,26 @@ func (f *connectionsFactory) Create() (*grpc.ClientConn, error) {
 		grpc.WithDefaultCallOptions(
 			grpc.MaxCallSendMsgSize(BufferSize),
 			grpc.MaxCallRecvMsgSize(BufferSize)))
+}
+
+func databaseUnaryInterceptor(database string) grpc.UnaryClientInterceptor {
+	return func(
+		ctx context.Context,
+		method string,
+		req any,
+		reply any,
+		cc *grpc.ClientConn,
+		invoker grpc.UnaryInvoker,
+		opts ...grpc.CallOption,
+	) error {
+		if database != "" {
+			md, _ := metadata.FromOutgoingContext(ctx)
+			md = md.Copy()
+			md.Set(databaseHeader, database)
+			ctx = metadata.NewOutgoingContext(ctx, md)
+		}
+		return invoker(ctx, method, req, reply, cc, opts...)
+	}
 }
 
 func endpoint(config Config) string {

--- a/pkg/client/connectionsfactory/connectionsfactory_suite_test.go
+++ b/pkg/client/connectionsfactory/connectionsfactory_suite_test.go
@@ -1,0 +1,13 @@
+package connectionsfactory
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestConnectionsFactory(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Connections Factory Suite")
+}

--- a/pkg/client/connectionsfactory/database_test.go
+++ b/pkg/client/connectionsfactory/database_test.go
@@ -1,0 +1,41 @@
+package connectionsfactory
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+)
+
+var _ = Describe("Database metadata", func() {
+	DescribeTable("unary interceptor",
+		func(database string, initialDatabase string, expectedDatabase []string) {
+			ctx := metadata.AppendToOutgoingContext(context.Background(), "x-ydb-auth-ticket", "token")
+			if initialDatabase != "" {
+				ctx = metadata.AppendToOutgoingContext(ctx, databaseHeader, initialDatabase)
+			}
+
+			var got metadata.MD
+			invoker := func(
+				ctx context.Context,
+				_ string,
+				_ any,
+				_ any,
+				_ *grpc.ClientConn,
+				_ ...grpc.CallOption,
+			) error {
+				got, _ = metadata.FromOutgoingContext(ctx)
+				return nil
+			}
+
+			Expect(databaseUnaryInterceptor(database)(ctx, "method", nil, nil, nil, invoker)).To(Succeed())
+			Expect(got.Get(databaseHeader)).To(Equal(expectedDatabase))
+			Expect(got.Get("x-ydb-auth-ticket")).To(Equal([]string{"token"}))
+		},
+		Entry("adds database", "/Root", "", []string{"/Root"}),
+		Entry("overrides database", "/Root", "/Old", []string{"/Root"}),
+		Entry("keeps database unset", "", "", []string(nil)),
+	)
+})

--- a/pkg/options/grpc.go
+++ b/pkg/options/grpc.go
@@ -22,6 +22,7 @@ const (
 
 type GRPC struct {
 	Endpoint       string
+	Database       string
 	CaFile         string
 	GRPCSecure     bool
 	GRPCPort       int
@@ -35,6 +36,11 @@ func (o *GRPC) DefineFlags(fs *pflag.FlagSet) {
 		"",
 		fmt.Sprintf(`PROTOCOL://HOST[:PORT]
   A GRPC URL to connect to the YDB cluster. Default port is %v`, GRPCDefaultPort))
+
+	profile.PopulateFromProfileLaterP(
+		fs.StringVarP, &o.Database, "database", "d",
+		"",
+		"Database path used for YDB requests")
 
 	fs.IntVar(&o.TimeoutSeconds, "grpc-timeout-seconds", GRPCDefaultTimeoutSeconds,
 		"Wait this much before timing out any GRPC requests")

--- a/tests/mock/server.go
+++ b/tests/mock/server.go
@@ -20,7 +20,10 @@ import (
 	"github.com/ydb-platform/ydb-go-genproto/protos/Ydb_Discovery"
 	"github.com/ydb-platform/ydb-go-genproto/protos/Ydb_Operations"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -58,6 +61,7 @@ type YdbMock struct {
 	caFile                  string
 	keyFile                 string
 	additionalTestBehaviour AdditionalTestBehaviour
+	requiredDatabase        string
 
 	// This field contains the list of Nodes that is suitable to return
 	// to ListClusterNodes request from rolling restart.
@@ -302,16 +306,15 @@ func (s *YdbMock) StartOn(port int) {
 		log.Fatalf("failed to listen: %v", err)
 	}
 
+	serverOptions := []grpc.ServerOption{grpc.UnaryInterceptor(s.requireDatabase)}
 	if s.caFile != "" && s.keyFile != "" {
 		creds, err := credentials.NewServerTLSFromFile(s.caFile, s.keyFile)
 		if err != nil {
 			log.Fatal(err)
 		}
-
-		s.grpcServer = grpc.NewServer(grpc.Creds(creds))
-	} else {
-		s.grpcServer = grpc.NewServer()
+		serverOptions = append(serverOptions, grpc.Creds(creds))
 	}
+	s.grpcServer = grpc.NewServer(serverOptions...)
 
 	Ydb_Maintenance_V1.RegisterMaintenanceServiceServer(s.grpcServer, s)
 	Ydb_Auth_V1.RegisterAuthServiceServer(s.grpcServer, s)
@@ -323,10 +326,29 @@ func (s *YdbMock) StartOn(port int) {
 	}()
 }
 
+func (s *YdbMock) requireDatabase(
+	ctx context.Context,
+	req any,
+	_ *grpc.UnaryServerInfo,
+	handler grpc.UnaryHandler,
+) (any, error) {
+	if s.requiredDatabase != "" {
+		values := metadata.ValueFromIncomingContext(ctx, "x-ydb-database")
+		if len(values) != 1 || values[0] != s.requiredDatabase {
+			return nil, status.Errorf(codes.InvalidArgument, "database metadata = %v, want [%s]", values, s.requiredDatabase)
+		}
+	}
+	return handler(ctx, req)
+}
+
 func (s *YdbMock) Teardown() {
 	s.grpcServer.GracefulStop()
 }
 
 func (s *YdbMock) SetMockBehaviour(additionalMockBehaviour AdditionalTestBehaviour) {
 	s.additionalTestBehaviour = additionalMockBehaviour
+}
+
+func (s *YdbMock) SetRequiredDatabase(database string) {
+	s.requiredDatabase = database
 }

--- a/tests/profile_test.go
+++ b/tests/profile_test.go
@@ -19,6 +19,7 @@ var _ = Describe("Test Profile", func() {
 
 	DescribeTable("profile", RunTestCase,
 		Entry("some basic options, no --profile option, current-profile in config", TestCase{
+			requiredDatabase: "/Root",
 			nodeConfiguration: [][]uint32{
 				{1, 2, 3, 4, 5, 6, 7, 8},
 			},
@@ -96,6 +97,7 @@ var _ = Describe("Test Profile", func() {
 		},
 		),
 		Entry("some basic options, --profile option specified, no current-profile in config", TestCase{
+			requiredDatabase: "/Root",
 			nodeConfiguration: [][]uint32{
 				{1, 2, 3, 4, 5, 6, 7, 8},
 			},

--- a/tests/rolling_test.go
+++ b/tests/rolling_test.go
@@ -25,6 +25,7 @@ var _ = Describe("Test Rolling", func() {
 
 	DescribeTable("restart", RunTestCase,
 		Entry("restart 2 out of 8 nodes, nodes should be determined by --started filter", TestCase{
+			requiredDatabase: "/Root",
 			nodeConfiguration: [][]uint32{
 				{1, 2, 3, 4, 5, 6, 7, 8},
 			},
@@ -40,6 +41,7 @@ var _ = Describe("Test Rolling", func() {
 				{
 					ydbopsInvocation: Command{
 						"--endpoint", "grpcs://localhost:2135",
+						"--database", "/Root",
 						"--verbose",
 						"--availability-mode", "strong",
 						"--user", mock.TestUser,

--- a/tests/run_e2e_test.go
+++ b/tests/run_e2e_test.go
@@ -39,6 +39,7 @@ type StepData struct {
 type TestCase struct {
 	nodeConfiguration [][]uint32
 	nodeInfoMap       map[uint32]mock.TestNodeInfo
+	requiredDatabase  string
 
 	steps                   []StepData
 	additionalTestBehaviour *mock.AdditionalTestBehaviour
@@ -85,6 +86,7 @@ func RunAfterEach() {
 
 func RunTestCase(tc TestCase) {
 	ydb.SetNodeConfiguration(tc.nodeConfiguration, tc.nodeInfoMap)
+	ydb.SetRequiredDatabase(tc.requiredDatabase)
 
 	if tc.additionalTestBehaviour == nil {
 		tc.additionalTestBehaviour = &mock.AdditionalTestBehaviour{}

--- a/tests/test-data/config_with_current_profile.yaml
+++ b/tests/test-data/config_with_current_profile.yaml
@@ -2,5 +2,6 @@ current-profile: my-profile
 profiles:
   my-profile:
     endpoint: grpcs://localhost:2135
+    database: /Root
     user: test-user
     ca-file: ./test-data/ssl-data/ca.crt

--- a/tests/test-data/config_without_current_profile.yaml
+++ b/tests/test-data/config_without_current_profile.yaml
@@ -1,5 +1,6 @@
 profiles:
   my-profile:
     endpoint: grpcs://localhost:2135
+    database: /Root
     user: test-user
     ca-file: ./test-data/ssl-data/ca.crt


### PR DESCRIPTION
## What changed

- add the global `--database` / `-d` option and profile support;
- attach `x-ydb-database` to every unary YDB RPC while preserving authentication metadata;
- verify direct CLI and profile propagation against a mock server that rejects missing database metadata;
- document the required database argument and add a changelog fragment.

## Why

YDB now rejects `Discovery.WhoAmI` and `Auth.Login` on static nodes when the database context is empty. `ydbops v0.0.27` has no way to send that context, so rolling restart fails before it can create a maintenance task.

The option remains optional for compatibility with deployments whose server still accepts database-less CMS and Maintenance requests. `ydb-ansible` will pass `/Root` explicitly after this change is released.

Related server changes:

- ydb-platform/ydb#36761
- ydb-platform/ydb#44058

## Checks

- `go test -v -p 1 ./... -args -ginkgo.v`
- `go vet ./...`
- `git diff --check`
